### PR TITLE
Serialize and deserialize fixed-length arrays like ROS does

### DIFF
--- a/Runtime/MessageGeneration/common_msgs/Actionlib/msg/GoalStatusArray.cs
+++ b/Runtime/MessageGeneration/common_msgs/Actionlib/msg/GoalStatusArray.cs
@@ -46,7 +46,7 @@ namespace RosMessageTypes.Actionlib
             var status_listArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.status_list= new GoalStatus[status_listArrayLength];
-            for(var i =0; i <status_listArrayLength; i++)
+            for(var i = 0; i < status_listArrayLength; i++)
             {
                 this.status_list[i] = new GoalStatus();
                 offset = this.status_list[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Diagnostic/msg/DiagnosticArray.cs
+++ b/Runtime/MessageGeneration/common_msgs/Diagnostic/msg/DiagnosticArray.cs
@@ -47,7 +47,7 @@ namespace RosMessageTypes.Diagnostic
             var statusArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.status= new DiagnosticStatus[statusArrayLength];
-            for(var i =0; i <statusArrayLength; i++)
+            for(var i = 0; i < statusArrayLength; i++)
             {
                 this.status[i] = new DiagnosticStatus();
                 offset = this.status[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Diagnostic/msg/DiagnosticStatus.cs
+++ b/Runtime/MessageGeneration/common_msgs/Diagnostic/msg/DiagnosticStatus.cs
@@ -80,7 +80,7 @@ namespace RosMessageTypes.Diagnostic
             var valuesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.values= new KeyValue[valuesArrayLength];
-            for(var i =0; i <valuesArrayLength; i++)
+            for(var i = 0; i < valuesArrayLength; i++)
             {
                 this.values[i] = new KeyValue();
                 offset = this.values[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Geometry/msg/AccelWithCovariance.cs
+++ b/Runtime/MessageGeneration/common_msgs/Geometry/msg/AccelWithCovariance.cs
@@ -34,7 +34,7 @@ namespace RosMessageTypes.Geometry
             var listOfSerializations = new List<byte[]>();
             listOfSerializations.AddRange(accel.SerializationStatements());
             
-            listOfSerializations.Add(BitConverter.GetBytes(covariance.Length));
+            Array.Resize(ref covariance, 36);
             foreach(var entry in covariance)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
 
@@ -45,10 +45,8 @@ namespace RosMessageTypes.Geometry
         {
             offset = this.accel.Deserialize(data, offset);
             
-            var covarianceArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.covariance= new double[covarianceArrayLength];
-            for(var i =0; i <covarianceArrayLength; i++)
+            this.covariance= new double[36];
+            for(var i = 0; i < 36; i++)
             {
                 this.covariance[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;

--- a/Runtime/MessageGeneration/common_msgs/Geometry/msg/Polygon.cs
+++ b/Runtime/MessageGeneration/common_msgs/Geometry/msg/Polygon.cs
@@ -39,7 +39,7 @@ namespace RosMessageTypes.Geometry
             var pointsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.points= new Point32[pointsArrayLength];
-            for(var i =0; i <pointsArrayLength; i++)
+            for(var i = 0; i < pointsArrayLength; i++)
             {
                 this.points[i] = new Point32();
                 offset = this.points[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Geometry/msg/PoseArray.cs
+++ b/Runtime/MessageGeneration/common_msgs/Geometry/msg/PoseArray.cs
@@ -45,7 +45,7 @@ namespace RosMessageTypes.Geometry
             var posesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.poses= new Pose[posesArrayLength];
-            for(var i =0; i <posesArrayLength; i++)
+            for(var i = 0; i < posesArrayLength; i++)
             {
                 this.poses[i] = new Pose();
                 offset = this.poses[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Geometry/msg/PoseWithCovariance.cs
+++ b/Runtime/MessageGeneration/common_msgs/Geometry/msg/PoseWithCovariance.cs
@@ -34,7 +34,7 @@ namespace RosMessageTypes.Geometry
             var listOfSerializations = new List<byte[]>();
             listOfSerializations.AddRange(pose.SerializationStatements());
             
-            listOfSerializations.Add(BitConverter.GetBytes(covariance.Length));
+            Array.Resize(ref covariance, 36);
             foreach(var entry in covariance)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
 
@@ -45,10 +45,8 @@ namespace RosMessageTypes.Geometry
         {
             offset = this.pose.Deserialize(data, offset);
             
-            var covarianceArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.covariance= new double[covarianceArrayLength];
-            for(var i =0; i <covarianceArrayLength; i++)
+            this.covariance= new double[36];
+            for(var i = 0; i < 36; i++)
             {
                 this.covariance[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;

--- a/Runtime/MessageGeneration/common_msgs/Geometry/msg/TwistWithCovariance.cs
+++ b/Runtime/MessageGeneration/common_msgs/Geometry/msg/TwistWithCovariance.cs
@@ -34,7 +34,7 @@ namespace RosMessageTypes.Geometry
             var listOfSerializations = new List<byte[]>();
             listOfSerializations.AddRange(twist.SerializationStatements());
             
-            listOfSerializations.Add(BitConverter.GetBytes(covariance.Length));
+            Array.Resize(ref covariance, 36);
             foreach(var entry in covariance)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
 
@@ -45,10 +45,8 @@ namespace RosMessageTypes.Geometry
         {
             offset = this.twist.Deserialize(data, offset);
             
-            var covarianceArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.covariance= new double[covarianceArrayLength];
-            for(var i =0; i <covarianceArrayLength; i++)
+            this.covariance= new double[36];
+            for(var i = 0; i < 36; i++)
             {
                 this.covariance[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;

--- a/Runtime/MessageGeneration/common_msgs/Nav/msg/GridCells.cs
+++ b/Runtime/MessageGeneration/common_msgs/Nav/msg/GridCells.cs
@@ -57,7 +57,7 @@ namespace RosMessageTypes.Nav
             var cellsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.cells= new Geometry.Point[cellsArrayLength];
-            for(var i =0; i <cellsArrayLength; i++)
+            for(var i = 0; i < cellsArrayLength; i++)
             {
                 this.cells[i] = new Geometry.Point();
                 offset = this.cells[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Nav/msg/OccupancyGrid.cs
+++ b/Runtime/MessageGeneration/common_msgs/Nav/msg/OccupancyGrid.cs
@@ -53,7 +53,7 @@ namespace RosMessageTypes.Nav
             var dataArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.data= new sbyte[dataArrayLength];
-            for(var i =0; i <dataArrayLength; i++)
+            for(var i = 0; i < dataArrayLength; i++)
             {
                 this.data[i] = (sbyte)data[offset];
                 offset += 1;

--- a/Runtime/MessageGeneration/common_msgs/Nav/msg/Path.cs
+++ b/Runtime/MessageGeneration/common_msgs/Nav/msg/Path.cs
@@ -45,7 +45,7 @@ namespace RosMessageTypes.Nav
             var posesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.poses= new Geometry.PoseStamped[posesArrayLength];
-            for(var i =0; i <posesArrayLength; i++)
+            for(var i = 0; i < posesArrayLength; i++)
             {
                 this.poses[i] = new Geometry.PoseStamped();
                 offset = this.poses[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/BatteryState.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/BatteryState.cs
@@ -170,7 +170,7 @@ namespace RosMessageTypes.Sensor
             var cell_voltageArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.cell_voltage= new float[cell_voltageArrayLength];
-            for(var i =0; i <cell_voltageArrayLength; i++)
+            for(var i = 0; i < cell_voltageArrayLength; i++)
             {
                 this.cell_voltage[i] = BitConverter.ToSingle(data, offset);
                 offset += 4;
@@ -179,7 +179,7 @@ namespace RosMessageTypes.Sensor
             var cell_temperatureArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.cell_temperature= new float[cell_temperatureArrayLength];
-            for(var i =0; i <cell_temperatureArrayLength; i++)
+            for(var i = 0; i < cell_temperatureArrayLength; i++)
             {
                 this.cell_temperature[i] = BitConverter.ToSingle(data, offset);
                 offset += 4;

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/CameraInfo.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/CameraInfo.cs
@@ -174,15 +174,15 @@ namespace RosMessageTypes.Sensor
             foreach(var entry in D)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
             
-            listOfSerializations.Add(BitConverter.GetBytes(K.Length));
+            Array.Resize(ref K, 9);
             foreach(var entry in K)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
             
-            listOfSerializations.Add(BitConverter.GetBytes(R.Length));
+            Array.Resize(ref R, 9);
             foreach(var entry in R)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
             
-            listOfSerializations.Add(BitConverter.GetBytes(P.Length));
+            Array.Resize(ref P, 12);
             foreach(var entry in P)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
             listOfSerializations.Add(BitConverter.GetBytes(this.binning_x));
@@ -207,34 +207,28 @@ namespace RosMessageTypes.Sensor
             var DArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.D= new double[DArrayLength];
-            for(var i =0; i <DArrayLength; i++)
+            for(var i = 0; i < DArrayLength; i++)
             {
                 this.D[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;
             }
             
-            var KArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.K= new double[KArrayLength];
-            for(var i =0; i <KArrayLength; i++)
+            this.K= new double[9];
+            for(var i = 0; i < 9; i++)
             {
                 this.K[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;
             }
             
-            var RArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.R= new double[RArrayLength];
-            for(var i =0; i <RArrayLength; i++)
+            this.R= new double[9];
+            for(var i = 0; i < 9; i++)
             {
                 this.R[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;
             }
             
-            var PArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.P= new double[PArrayLength];
-            for(var i =0; i <PArrayLength; i++)
+            this.P= new double[12];
+            for(var i = 0; i < 12; i++)
             {
                 this.P[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/ChannelFloat32.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/ChannelFloat32.cs
@@ -65,7 +65,7 @@ namespace RosMessageTypes.Sensor
             var valuesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.values= new float[valuesArrayLength];
-            for(var i =0; i <valuesArrayLength; i++)
+            for(var i = 0; i < valuesArrayLength; i++)
             {
                 this.values[i] = BitConverter.ToSingle(data, offset);
                 offset += 4;

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/CompressedImage.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/CompressedImage.cs
@@ -62,7 +62,7 @@ namespace RosMessageTypes.Sensor
             var dataArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.data= new byte[dataArrayLength];
-            for(var i =0; i <dataArrayLength; i++)
+            for(var i = 0; i < dataArrayLength; i++)
             {
                 this.data[i] = data[offset];
                 offset += 1;

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/Image.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/Image.cs
@@ -97,7 +97,7 @@ namespace RosMessageTypes.Sensor
             var dataArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.data= new byte[dataArrayLength];
-            for(var i =0; i <dataArrayLength; i++)
+            for(var i = 0; i < dataArrayLength; i++)
             {
                 this.data[i] = data[offset];
                 offset += 1;

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/Imu.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/Imu.cs
@@ -62,17 +62,17 @@ namespace RosMessageTypes.Sensor
             listOfSerializations.AddRange(header.SerializationStatements());
             listOfSerializations.AddRange(orientation.SerializationStatements());
             
-            listOfSerializations.Add(BitConverter.GetBytes(orientation_covariance.Length));
+            Array.Resize(ref orientation_covariance, 9);
             foreach(var entry in orientation_covariance)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
             listOfSerializations.AddRange(angular_velocity.SerializationStatements());
             
-            listOfSerializations.Add(BitConverter.GetBytes(angular_velocity_covariance.Length));
+            Array.Resize(ref angular_velocity_covariance, 9);
             foreach(var entry in angular_velocity_covariance)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
             listOfSerializations.AddRange(linear_acceleration.SerializationStatements());
             
-            listOfSerializations.Add(BitConverter.GetBytes(linear_acceleration_covariance.Length));
+            Array.Resize(ref linear_acceleration_covariance, 9);
             foreach(var entry in linear_acceleration_covariance)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
 
@@ -84,30 +84,24 @@ namespace RosMessageTypes.Sensor
             offset = this.header.Deserialize(data, offset);
             offset = this.orientation.Deserialize(data, offset);
             
-            var orientation_covarianceArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.orientation_covariance= new double[orientation_covarianceArrayLength];
-            for(var i =0; i <orientation_covarianceArrayLength; i++)
+            this.orientation_covariance= new double[9];
+            for(var i = 0; i < 9; i++)
             {
                 this.orientation_covariance[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;
             }
             offset = this.angular_velocity.Deserialize(data, offset);
             
-            var angular_velocity_covarianceArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.angular_velocity_covariance= new double[angular_velocity_covarianceArrayLength];
-            for(var i =0; i <angular_velocity_covarianceArrayLength; i++)
+            this.angular_velocity_covariance= new double[9];
+            for(var i = 0; i < 9; i++)
             {
                 this.angular_velocity_covariance[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;
             }
             offset = this.linear_acceleration.Deserialize(data, offset);
             
-            var linear_acceleration_covarianceArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.linear_acceleration_covariance= new double[linear_acceleration_covarianceArrayLength];
-            for(var i =0; i <linear_acceleration_covarianceArrayLength; i++)
+            this.linear_acceleration_covariance= new double[9];
+            for(var i = 0; i < 9; i++)
             {
                 this.linear_acceleration_covariance[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/JointState.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/JointState.cs
@@ -83,7 +83,7 @@ namespace RosMessageTypes.Sensor
             var nameArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.name= new string[nameArrayLength];
-            for(var i =0; i <nameArrayLength; i++)
+            for(var i = 0; i < nameArrayLength; i++)
             {
                 var nameStringBytesLength = DeserializeLength(data, offset);
                 offset += 4;
@@ -94,7 +94,7 @@ namespace RosMessageTypes.Sensor
             var positionArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.position= new double[positionArrayLength];
-            for(var i =0; i <positionArrayLength; i++)
+            for(var i = 0; i < positionArrayLength; i++)
             {
                 this.position[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;
@@ -103,7 +103,7 @@ namespace RosMessageTypes.Sensor
             var velocityArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.velocity= new double[velocityArrayLength];
-            for(var i =0; i <velocityArrayLength; i++)
+            for(var i = 0; i < velocityArrayLength; i++)
             {
                 this.velocity[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;
@@ -112,7 +112,7 @@ namespace RosMessageTypes.Sensor
             var effortArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.effort= new double[effortArrayLength];
-            for(var i =0; i <effortArrayLength; i++)
+            for(var i = 0; i < effortArrayLength; i++)
             {
                 this.effort[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/Joy.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/Joy.cs
@@ -55,7 +55,7 @@ namespace RosMessageTypes.Sensor
             var axesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.axes= new float[axesArrayLength];
-            for(var i =0; i <axesArrayLength; i++)
+            for(var i = 0; i < axesArrayLength; i++)
             {
                 this.axes[i] = BitConverter.ToSingle(data, offset);
                 offset += 4;
@@ -64,7 +64,7 @@ namespace RosMessageTypes.Sensor
             var buttonsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.buttons= new int[buttonsArrayLength];
-            for(var i =0; i <buttonsArrayLength; i++)
+            for(var i = 0; i < buttonsArrayLength; i++)
             {
                 this.buttons[i] = BitConverter.ToInt32(data, offset);
                 offset += 4;

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/JoyFeedbackArray.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/JoyFeedbackArray.cs
@@ -39,7 +39,7 @@ namespace RosMessageTypes.Sensor
             var arrayArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.array= new JoyFeedback[arrayArrayLength];
-            for(var i =0; i <arrayArrayLength; i++)
+            for(var i = 0; i < arrayArrayLength; i++)
             {
                 this.array[i] = new JoyFeedback();
                 offset = this.array[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/LaserEcho.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/LaserEcho.cs
@@ -42,7 +42,7 @@ namespace RosMessageTypes.Sensor
             var echoesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.echoes= new float[echoesArrayLength];
-            for(var i =0; i <echoesArrayLength; i++)
+            for(var i = 0; i < echoesArrayLength; i++)
             {
                 this.echoes[i] = BitConverter.ToSingle(data, offset);
                 offset += 4;

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/LaserScan.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/LaserScan.cs
@@ -117,7 +117,7 @@ namespace RosMessageTypes.Sensor
             var rangesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.ranges= new float[rangesArrayLength];
-            for(var i =0; i <rangesArrayLength; i++)
+            for(var i = 0; i < rangesArrayLength; i++)
             {
                 this.ranges[i] = BitConverter.ToSingle(data, offset);
                 offset += 4;
@@ -126,7 +126,7 @@ namespace RosMessageTypes.Sensor
             var intensitiesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.intensities= new float[intensitiesArrayLength];
-            for(var i =0; i <intensitiesArrayLength; i++)
+            for(var i = 0; i < intensitiesArrayLength; i++)
             {
                 this.intensities[i] = BitConverter.ToSingle(data, offset);
                 offset += 4;

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/MagneticField.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/MagneticField.cs
@@ -51,7 +51,7 @@ namespace RosMessageTypes.Sensor
             listOfSerializations.AddRange(header.SerializationStatements());
             listOfSerializations.AddRange(magnetic_field.SerializationStatements());
             
-            listOfSerializations.Add(BitConverter.GetBytes(magnetic_field_covariance.Length));
+            Array.Resize(ref magnetic_field_covariance, 9);
             foreach(var entry in magnetic_field_covariance)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
 
@@ -63,10 +63,8 @@ namespace RosMessageTypes.Sensor
             offset = this.header.Deserialize(data, offset);
             offset = this.magnetic_field.Deserialize(data, offset);
             
-            var magnetic_field_covarianceArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.magnetic_field_covariance= new double[magnetic_field_covarianceArrayLength];
-            for(var i =0; i <magnetic_field_covarianceArrayLength; i++)
+            this.magnetic_field_covariance= new double[9];
+            for(var i = 0; i < 9; i++)
             {
                 this.magnetic_field_covariance[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/MultiDOFJointState.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/MultiDOFJointState.cs
@@ -84,7 +84,7 @@ namespace RosMessageTypes.Sensor
             var joint_namesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.joint_names= new string[joint_namesArrayLength];
-            for(var i =0; i <joint_namesArrayLength; i++)
+            for(var i = 0; i < joint_namesArrayLength; i++)
             {
                 var joint_namesStringBytesLength = DeserializeLength(data, offset);
                 offset += 4;
@@ -95,7 +95,7 @@ namespace RosMessageTypes.Sensor
             var transformsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.transforms= new Geometry.Transform[transformsArrayLength];
-            for(var i =0; i <transformsArrayLength; i++)
+            for(var i = 0; i < transformsArrayLength; i++)
             {
                 this.transforms[i] = new Geometry.Transform();
                 offset = this.transforms[i].Deserialize(data, offset);
@@ -104,7 +104,7 @@ namespace RosMessageTypes.Sensor
             var twistArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.twist= new Geometry.Twist[twistArrayLength];
-            for(var i =0; i <twistArrayLength; i++)
+            for(var i = 0; i < twistArrayLength; i++)
             {
                 this.twist[i] = new Geometry.Twist();
                 offset = this.twist[i].Deserialize(data, offset);
@@ -113,7 +113,7 @@ namespace RosMessageTypes.Sensor
             var wrenchArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.wrench= new Geometry.Wrench[wrenchArrayLength];
-            for(var i =0; i <wrenchArrayLength; i++)
+            for(var i = 0; i < wrenchArrayLength; i++)
             {
                 this.wrench[i] = new Geometry.Wrench();
                 offset = this.wrench[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/MultiEchoLaserScan.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/MultiEchoLaserScan.cs
@@ -119,7 +119,7 @@ namespace RosMessageTypes.Sensor
             var rangesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.ranges= new LaserEcho[rangesArrayLength];
-            for(var i =0; i <rangesArrayLength; i++)
+            for(var i = 0; i < rangesArrayLength; i++)
             {
                 this.ranges[i] = new LaserEcho();
                 offset = this.ranges[i].Deserialize(data, offset);
@@ -128,7 +128,7 @@ namespace RosMessageTypes.Sensor
             var intensitiesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.intensities= new LaserEcho[intensitiesArrayLength];
-            for(var i =0; i <intensitiesArrayLength; i++)
+            for(var i = 0; i < intensitiesArrayLength; i++)
             {
                 this.intensities[i] = new LaserEcho();
                 offset = this.intensities[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/NavSatFix.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/NavSatFix.cs
@@ -78,7 +78,7 @@ namespace RosMessageTypes.Sensor
             listOfSerializations.Add(BitConverter.GetBytes(this.longitude));
             listOfSerializations.Add(BitConverter.GetBytes(this.altitude));
             
-            listOfSerializations.Add(BitConverter.GetBytes(position_covariance.Length));
+            Array.Resize(ref position_covariance, 9);
             foreach(var entry in position_covariance)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
             listOfSerializations.Add(new[]{this.position_covariance_type});
@@ -97,10 +97,8 @@ namespace RosMessageTypes.Sensor
             this.altitude = BitConverter.ToDouble(data, offset);
             offset += 8;
             
-            var position_covarianceArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.position_covariance= new double[position_covarianceArrayLength];
-            for(var i =0; i <position_covarianceArrayLength; i++)
+            this.position_covariance= new double[9];
+            for(var i = 0; i < 9; i++)
             {
                 this.position_covariance[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/PointCloud.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/PointCloud.cs
@@ -59,7 +59,7 @@ namespace RosMessageTypes.Sensor
             var pointsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.points= new Geometry.Point32[pointsArrayLength];
-            for(var i =0; i <pointsArrayLength; i++)
+            for(var i = 0; i < pointsArrayLength; i++)
             {
                 this.points[i] = new Geometry.Point32();
                 offset = this.points[i].Deserialize(data, offset);
@@ -68,7 +68,7 @@ namespace RosMessageTypes.Sensor
             var channelsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.channels= new ChannelFloat32[channelsArrayLength];
-            for(var i =0; i <channelsArrayLength; i++)
+            for(var i = 0; i < channelsArrayLength; i++)
             {
                 this.channels[i] = new ChannelFloat32();
                 offset = this.channels[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Sensor/msg/PointCloud2.cs
+++ b/Runtime/MessageGeneration/common_msgs/Sensor/msg/PointCloud2.cs
@@ -95,7 +95,7 @@ namespace RosMessageTypes.Sensor
             var fieldsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.fields= new PointField[fieldsArrayLength];
-            for(var i =0; i <fieldsArrayLength; i++)
+            for(var i = 0; i < fieldsArrayLength; i++)
             {
                 this.fields[i] = new PointField();
                 offset = this.fields[i].Deserialize(data, offset);
@@ -110,7 +110,7 @@ namespace RosMessageTypes.Sensor
             var dataArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.data= new byte[dataArrayLength];
-            for(var i =0; i <dataArrayLength; i++)
+            for(var i = 0; i < dataArrayLength; i++)
             {
                 this.data[i] = data[offset];
                 offset += 1;

--- a/Runtime/MessageGeneration/common_msgs/Shape/msg/Mesh.cs
+++ b/Runtime/MessageGeneration/common_msgs/Shape/msg/Mesh.cs
@@ -48,7 +48,7 @@ namespace RosMessageTypes.Shape
             var trianglesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.triangles= new MeshTriangle[trianglesArrayLength];
-            for(var i =0; i <trianglesArrayLength; i++)
+            for(var i = 0; i < trianglesArrayLength; i++)
             {
                 this.triangles[i] = new MeshTriangle();
                 offset = this.triangles[i].Deserialize(data, offset);
@@ -57,7 +57,7 @@ namespace RosMessageTypes.Shape
             var verticesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.vertices= new Geometry.Point[verticesArrayLength];
-            for(var i =0; i <verticesArrayLength; i++)
+            for(var i = 0; i < verticesArrayLength; i++)
             {
                 this.vertices[i] = new Geometry.Point();
                 offset = this.vertices[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Shape/msg/MeshTriangle.cs
+++ b/Runtime/MessageGeneration/common_msgs/Shape/msg/MeshTriangle.cs
@@ -26,7 +26,7 @@ namespace RosMessageTypes.Shape
         {
             var listOfSerializations = new List<byte[]>();
             
-            listOfSerializations.Add(BitConverter.GetBytes(vertex_indices.Length));
+            Array.Resize(ref vertex_indices, 3);
             foreach(var entry in vertex_indices)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
 
@@ -36,10 +36,8 @@ namespace RosMessageTypes.Shape
         public override int Deserialize(byte[] data, int offset)
         {
             
-            var vertex_indicesArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.vertex_indices= new uint[vertex_indicesArrayLength];
-            for(var i =0; i <vertex_indicesArrayLength; i++)
+            this.vertex_indices= new uint[3];
+            for(var i = 0; i < 3; i++)
             {
                 this.vertex_indices[i] = BitConverter.ToUInt32(data, offset);
                 offset += 4;

--- a/Runtime/MessageGeneration/common_msgs/Shape/msg/Plane.cs
+++ b/Runtime/MessageGeneration/common_msgs/Shape/msg/Plane.cs
@@ -30,7 +30,7 @@ namespace RosMessageTypes.Shape
         {
             var listOfSerializations = new List<byte[]>();
             
-            listOfSerializations.Add(BitConverter.GetBytes(coef.Length));
+            Array.Resize(ref coef, 4);
             foreach(var entry in coef)
                 listOfSerializations.Add(BitConverter.GetBytes(entry));
 
@@ -40,10 +40,8 @@ namespace RosMessageTypes.Shape
         public override int Deserialize(byte[] data, int offset)
         {
             
-            var coefArrayLength = DeserializeLength(data, offset);
-            offset += 4;
-            this.coef= new double[coefArrayLength];
-            for(var i =0; i <coefArrayLength; i++)
+            this.coef= new double[4];
+            for(var i = 0; i < 4; i++)
             {
                 this.coef[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;

--- a/Runtime/MessageGeneration/common_msgs/Shape/msg/SolidPrimitive.cs
+++ b/Runtime/MessageGeneration/common_msgs/Shape/msg/SolidPrimitive.cs
@@ -72,7 +72,7 @@ namespace RosMessageTypes.Shape
             var dimensionsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.dimensions= new double[dimensionsArrayLength];
-            for(var i =0; i <dimensionsArrayLength; i++)
+            for(var i = 0; i < dimensionsArrayLength; i++)
             {
                 this.dimensions[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;

--- a/Runtime/MessageGeneration/common_msgs/Trajectory/msg/JointTrajectory.cs
+++ b/Runtime/MessageGeneration/common_msgs/Trajectory/msg/JointTrajectory.cs
@@ -51,7 +51,7 @@ namespace RosMessageTypes.Trajectory
             var joint_namesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.joint_names= new string[joint_namesArrayLength];
-            for(var i =0; i <joint_namesArrayLength; i++)
+            for(var i = 0; i < joint_namesArrayLength; i++)
             {
                 var joint_namesStringBytesLength = DeserializeLength(data, offset);
                 offset += 4;
@@ -62,7 +62,7 @@ namespace RosMessageTypes.Trajectory
             var pointsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.points= new JointTrajectoryPoint[pointsArrayLength];
-            for(var i =0; i <pointsArrayLength; i++)
+            for(var i = 0; i < pointsArrayLength; i++)
             {
                 this.points[i] = new JointTrajectoryPoint();
                 offset = this.points[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Trajectory/msg/JointTrajectoryPoint.cs
+++ b/Runtime/MessageGeneration/common_msgs/Trajectory/msg/JointTrajectoryPoint.cs
@@ -67,7 +67,7 @@ namespace RosMessageTypes.Trajectory
             var positionsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.positions= new double[positionsArrayLength];
-            for(var i =0; i <positionsArrayLength; i++)
+            for(var i = 0; i < positionsArrayLength; i++)
             {
                 this.positions[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;
@@ -76,7 +76,7 @@ namespace RosMessageTypes.Trajectory
             var velocitiesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.velocities= new double[velocitiesArrayLength];
-            for(var i =0; i <velocitiesArrayLength; i++)
+            for(var i = 0; i < velocitiesArrayLength; i++)
             {
                 this.velocities[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;
@@ -85,7 +85,7 @@ namespace RosMessageTypes.Trajectory
             var accelerationsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.accelerations= new double[accelerationsArrayLength];
-            for(var i =0; i <accelerationsArrayLength; i++)
+            for(var i = 0; i < accelerationsArrayLength; i++)
             {
                 this.accelerations[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;
@@ -94,7 +94,7 @@ namespace RosMessageTypes.Trajectory
             var effortArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.effort= new double[effortArrayLength];
-            for(var i =0; i <effortArrayLength; i++)
+            for(var i = 0; i < effortArrayLength; i++)
             {
                 this.effort[i] = BitConverter.ToDouble(data, offset);
                 offset += 8;

--- a/Runtime/MessageGeneration/common_msgs/Trajectory/msg/MultiDOFJointTrajectory.cs
+++ b/Runtime/MessageGeneration/common_msgs/Trajectory/msg/MultiDOFJointTrajectory.cs
@@ -56,7 +56,7 @@ namespace RosMessageTypes.Trajectory
             var joint_namesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.joint_names= new string[joint_namesArrayLength];
-            for(var i =0; i <joint_namesArrayLength; i++)
+            for(var i = 0; i < joint_namesArrayLength; i++)
             {
                 var joint_namesStringBytesLength = DeserializeLength(data, offset);
                 offset += 4;
@@ -67,7 +67,7 @@ namespace RosMessageTypes.Trajectory
             var pointsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.points= new MultiDOFJointTrajectoryPoint[pointsArrayLength];
-            for(var i =0; i <pointsArrayLength; i++)
+            for(var i = 0; i < pointsArrayLength; i++)
             {
                 this.points[i] = new MultiDOFJointTrajectoryPoint();
                 offset = this.points[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Trajectory/msg/MultiDOFJointTrajectoryPoint.cs
+++ b/Runtime/MessageGeneration/common_msgs/Trajectory/msg/MultiDOFJointTrajectoryPoint.cs
@@ -60,7 +60,7 @@ namespace RosMessageTypes.Trajectory
             var transformsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.transforms= new Geometry.Transform[transformsArrayLength];
-            for(var i =0; i <transformsArrayLength; i++)
+            for(var i = 0; i < transformsArrayLength; i++)
             {
                 this.transforms[i] = new Geometry.Transform();
                 offset = this.transforms[i].Deserialize(data, offset);
@@ -69,7 +69,7 @@ namespace RosMessageTypes.Trajectory
             var velocitiesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.velocities= new Geometry.Twist[velocitiesArrayLength];
-            for(var i =0; i <velocitiesArrayLength; i++)
+            for(var i = 0; i < velocitiesArrayLength; i++)
             {
                 this.velocities[i] = new Geometry.Twist();
                 offset = this.velocities[i].Deserialize(data, offset);
@@ -78,7 +78,7 @@ namespace RosMessageTypes.Trajectory
             var accelerationsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.accelerations= new Geometry.Twist[accelerationsArrayLength];
-            for(var i =0; i <accelerationsArrayLength; i++)
+            for(var i = 0; i < accelerationsArrayLength; i++)
             {
                 this.accelerations[i] = new Geometry.Twist();
                 offset = this.accelerations[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Visualization/msg/ImageMarker.cs
+++ b/Runtime/MessageGeneration/common_msgs/Visualization/msg/ImageMarker.cs
@@ -127,7 +127,7 @@ namespace RosMessageTypes.Visualization
             var pointsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.points= new Geometry.Point[pointsArrayLength];
-            for(var i =0; i <pointsArrayLength; i++)
+            for(var i = 0; i < pointsArrayLength; i++)
             {
                 this.points[i] = new Geometry.Point();
                 offset = this.points[i].Deserialize(data, offset);
@@ -136,7 +136,7 @@ namespace RosMessageTypes.Visualization
             var outline_colorsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.outline_colors= new Std.ColorRGBA[outline_colorsArrayLength];
-            for(var i =0; i <outline_colorsArrayLength; i++)
+            for(var i = 0; i < outline_colorsArrayLength; i++)
             {
                 this.outline_colors[i] = new Std.ColorRGBA();
                 offset = this.outline_colors[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Visualization/msg/InteractiveMarker.cs
+++ b/Runtime/MessageGeneration/common_msgs/Visualization/msg/InteractiveMarker.cs
@@ -91,7 +91,7 @@ namespace RosMessageTypes.Visualization
             var menu_entriesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.menu_entries= new MenuEntry[menu_entriesArrayLength];
-            for(var i =0; i <menu_entriesArrayLength; i++)
+            for(var i = 0; i < menu_entriesArrayLength; i++)
             {
                 this.menu_entries[i] = new MenuEntry();
                 offset = this.menu_entries[i].Deserialize(data, offset);
@@ -100,7 +100,7 @@ namespace RosMessageTypes.Visualization
             var controlsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.controls= new InteractiveMarkerControl[controlsArrayLength];
-            for(var i =0; i <controlsArrayLength; i++)
+            for(var i = 0; i < controlsArrayLength; i++)
             {
                 this.controls[i] = new InteractiveMarkerControl();
                 offset = this.controls[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Visualization/msg/InteractiveMarkerControl.cs
+++ b/Runtime/MessageGeneration/common_msgs/Visualization/msg/InteractiveMarkerControl.cs
@@ -130,7 +130,7 @@ namespace RosMessageTypes.Visualization
             var markersArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.markers= new Marker[markersArrayLength];
-            for(var i =0; i <markersArrayLength; i++)
+            for(var i = 0; i < markersArrayLength; i++)
             {
                 this.markers[i] = new Marker();
                 offset = this.markers[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Visualization/msg/InteractiveMarkerInit.cs
+++ b/Runtime/MessageGeneration/common_msgs/Visualization/msg/InteractiveMarkerInit.cs
@@ -61,7 +61,7 @@ namespace RosMessageTypes.Visualization
             var markersArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.markers= new InteractiveMarker[markersArrayLength];
-            for(var i =0; i <markersArrayLength; i++)
+            for(var i = 0; i < markersArrayLength; i++)
             {
                 this.markers[i] = new InteractiveMarker();
                 offset = this.markers[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Visualization/msg/InteractiveMarkerUpdate.cs
+++ b/Runtime/MessageGeneration/common_msgs/Visualization/msg/InteractiveMarkerUpdate.cs
@@ -90,7 +90,7 @@ namespace RosMessageTypes.Visualization
             var markersArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.markers= new InteractiveMarker[markersArrayLength];
-            for(var i =0; i <markersArrayLength; i++)
+            for(var i = 0; i < markersArrayLength; i++)
             {
                 this.markers[i] = new InteractiveMarker();
                 offset = this.markers[i].Deserialize(data, offset);
@@ -99,7 +99,7 @@ namespace RosMessageTypes.Visualization
             var posesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.poses= new InteractiveMarkerPose[posesArrayLength];
-            for(var i =0; i <posesArrayLength; i++)
+            for(var i = 0; i < posesArrayLength; i++)
             {
                 this.poses[i] = new InteractiveMarkerPose();
                 offset = this.poses[i].Deserialize(data, offset);
@@ -108,7 +108,7 @@ namespace RosMessageTypes.Visualization
             var erasesArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.erases= new string[erasesArrayLength];
-            for(var i =0; i <erasesArrayLength; i++)
+            for(var i = 0; i < erasesArrayLength; i++)
             {
                 var erasesStringBytesLength = DeserializeLength(data, offset);
                 offset += 4;

--- a/Runtime/MessageGeneration/common_msgs/Visualization/msg/Marker.cs
+++ b/Runtime/MessageGeneration/common_msgs/Visualization/msg/Marker.cs
@@ -148,7 +148,7 @@ namespace RosMessageTypes.Visualization
             var pointsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.points= new Geometry.Point[pointsArrayLength];
-            for(var i =0; i <pointsArrayLength; i++)
+            for(var i = 0; i < pointsArrayLength; i++)
             {
                 this.points[i] = new Geometry.Point();
                 offset = this.points[i].Deserialize(data, offset);
@@ -157,7 +157,7 @@ namespace RosMessageTypes.Visualization
             var colorsArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.colors= new Std.ColorRGBA[colorsArrayLength];
-            for(var i =0; i <colorsArrayLength; i++)
+            for(var i = 0; i < colorsArrayLength; i++)
             {
                 this.colors[i] = new Std.ColorRGBA();
                 offset = this.colors[i].Deserialize(data, offset);

--- a/Runtime/MessageGeneration/common_msgs/Visualization/msg/MarkerArray.cs
+++ b/Runtime/MessageGeneration/common_msgs/Visualization/msg/MarkerArray.cs
@@ -38,7 +38,7 @@ namespace RosMessageTypes.Visualization
             var markersArrayLength = DeserializeLength(data, offset);
             offset += 4;
             this.markers= new Marker[markersArrayLength];
-            for(var i =0; i <markersArrayLength; i++)
+            for(var i = 0; i < markersArrayLength; i++)
             {
                 this.markers[i] = new Marker();
                 offset = this.markers[i].Deserialize(data, offset);


### PR DESCRIPTION
When a message (e.g. sensor_msgs.Imu) defines the exact length of an array, ROS doesn't bother sending its length because everyone knows it already. We need to match this behaviour.

Tested by sending Imu messages from Unity and checking that rostopic views them correctly