### PR TITLE
Improving the way messages are sent over TCP to avoid unnecessary memory copies and thus reducing GC calls improving framerates. This is particularly noticable with Image topics.

### DIFF
--- a/InfoAcknowledgements.md.meta
+++ b/InfoAcknowledgements.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 32bde4001ffdbd5fc9ab5c69d87dedc2
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/InfoAcknowledgements.md.meta
+++ b/InfoAcknowledgements.md.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 32bde4001ffdbd5fc9ab5c69d87dedc2
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
The existing code 'byte[] messageBytes = GetMessageBytes(rosTopicName, message);' is used to amalgamate all the data of a message into a single byte array before it is sent over TCP to ROS. This step doesn't need to be done if the parts of the message are just sent sequentially. The benefit of this is that less memory is allocated that the GC will have to clean up later. Removing this step has dramatically increased my framerate due to less GC calls when publishing Image topics.