### PR TITLE
Use only one connection for all publishers

### DIFF
--- a/Runtime/ROSGeometry/ROSQuaternion.cs
+++ b/Runtime/ROSGeometry/ROSQuaternion.cs
@@ -142,7 +142,10 @@ namespace ROSGeometry
             axis = uaxis.To<C>();
         }
 
+#if UNITY_2020_1_OR_NEWER
         public string ToString(string format, IFormatProvider formatProvider) => internalQuat.ToString(format, formatProvider);
+#endif
+
         public string ToString(string format) => internalQuat.ToString(format);
         public override string ToString() => internalQuat.ToString();
     }

--- a/Runtime/ROSGeometry/ROSVector3.cs
+++ b/Runtime/ROSGeometry/ROSVector3.cs
@@ -199,7 +199,12 @@ namespace ROSGeometry
         
         public string ToString(string format) => internalVector.ToString(format);
         public override string ToString() => internalVector.ToString();
+
+#if UNITY_2020_1_OR_NEWER
         public string ToString(string format, System.IFormatProvider formatProvider) => internalVector.ToString(format, formatProvider);
+#else
+        public string ToString(string format, System.IFormatProvider formatProvider) => internalVector.ToString(format);
+#endif
 
         public static Vector3<C> operator +(Vector3<C> a, Vector3<C> b)
         {


### PR DESCRIPTION
Opening a new PR for this feature. I opened the equivalent on the ROS-TCP-Endpoint
The idea is to open only one connection for all publishers for faster publishing
The Unity client sends the server a service message to activate/deactivate this feature.
It's still possible to open one connection per send.

I thought about opening one connection for all subscribers or one connection per subscriber but that would require to change how data reception is handled because that would need threads for the reception part to prevent message queuing which would not go well with callbacks in my opinion