### PR TITLE
Fixing message name that should not take a capital first letter automatically

### DIFF
--- a/Runtime/MessageGeneration/MessageParser.cs
+++ b/Runtime/MessageGeneration/MessageParser.cs
@@ -72,6 +72,8 @@ namespace RosMessageGeneration
 
             if (rosMsgName.Equals(""))
             {
+                if (Char.IsLower(inFileName[0]))
+                    Debug.LogWarningFormat("File {0} starts with a lowercase character. Message file names should be CamelCased (see : http://wiki.ros.org/ROS/Patterns/Conventions#line-38)", inFileName);
                 this.rosMsgName = inFileName;
             }
             else

--- a/Runtime/MessageGeneration/MessageParser.cs
+++ b/Runtime/MessageGeneration/MessageParser.cs
@@ -72,7 +72,7 @@ namespace RosMessageGeneration
 
             if (rosMsgName.Equals(""))
             {
-                this.rosMsgName = MsgAutoGenUtilities.CapitalizeFirstLetter(inFileName);
+                this.rosMsgName = inFileName;
             }
             else
             {


### PR DESCRIPTION
This fixes a small issue where message name variable was capitalized when it shouldn't (making ros unable to recognize the message type)