### PR TITLE
Amanda/read chunks

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Editor/ROSSettingsEditor.cs
+++ b/com.unity.robotics.ros-tcp-connector/Editor/ROSSettingsEditor.cs
@@ -58,10 +58,10 @@ namespace Unity.Robotics.ROSTCPConnector.Editor
                 new GUIContent("Sleep (seconds)",
                     "While waiting for a service to respond, wait this many seconds between checks."),
                 prefab.awaitDataSleepSeconds);
-            prefab.byteChunkToRead = EditorGUILayout.IntField(
+            prefab.readChunkSize = EditorGUILayout.IntField(
                 new GUIContent("Read chunk size",
                     "While reading received messages, read this many bytes at a time."),
-                prefab.byteChunkToRead);
+                prefab.readChunkSize);
 
             if (GUI.changed)
             {

--- a/com.unity.robotics.ros-tcp-connector/Editor/ROSSettingsEditor.cs
+++ b/com.unity.robotics.ros-tcp-connector/Editor/ROSSettingsEditor.cs
@@ -58,6 +58,10 @@ namespace Unity.Robotics.ROSTCPConnector.Editor
                 new GUIContent("Sleep (seconds)",
                     "While waiting for a service to respond, wait this many seconds between checks."),
                 prefab.awaitDataSleepSeconds);
+            prefab.byteChunkToRead = EditorGUILayout.IntField(
+                new GUIContent("Read chunk size",
+                    "While reading received messages, read this many bytes at a time."),
+                prefab.byteChunkToRead);
 
             if (GUI.changed)
             {

--- a/com.unity.robotics.ros-tcp-connector/Editor/ROSSettingsEditor.cs
+++ b/com.unity.robotics.ros-tcp-connector/Editor/ROSSettingsEditor.cs
@@ -11,7 +11,7 @@ namespace Unity.Robotics.ROSTCPConnector.Editor
         {
             ROSSettingsEditor window = GetWindow<ROSSettingsEditor>(false, "ROS Settings", true);
             window.minSize = new Vector2(300, 65);
-            window.maxSize = new Vector2(600, 200);
+            window.maxSize = new Vector2(600, 250);
             window.Show();
         }
 
@@ -51,7 +51,7 @@ namespace Unity.Robotics.ROSTCPConnector.Editor
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("If awaiting a service response:", EditorStyles.boldLabel);
             prefab.awaitDataMaxRetries = EditorGUILayout.IntField(
-                new GUIContent("Max Retries",
+                new GUIContent("Max Service Retries",
                     "While waiting for a service to respond, check this many times before giving up."),
                 prefab.awaitDataMaxRetries);
             prefab.awaitDataSleepSeconds = EditorGUILayout.FloatField(
@@ -62,6 +62,10 @@ namespace Unity.Robotics.ROSTCPConnector.Editor
                 new GUIContent("Read chunk size",
                     "While reading received messages, read this many bytes at a time."),
                 prefab.readChunkSize);
+            prefab.awaitDataReadRetry = EditorGUILayout.IntField(
+                new GUIContent("Max Read retries",
+                    "While waiting to read a full message, check this many times before giving up."),
+                prefab.awaitDataReadRetry);
 
             if (GUI.changed)
             {

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -33,6 +33,9 @@ namespace Unity.Robotics.ROSTCPConnector
         [Tooltip("While waiting for a service to respond, wait this many seconds between checks.")]
         public float awaitDataSleepSeconds = 1.0f;
 
+        [Tooltip("While reading received messages, read this many bytes at a time.")]
+        public int byteChunkToRead = 2048;
+
         static object _lock = new object(); // sync lock 
         static List<Task> activeConnectionTasks = new List<Task>(); // pending connections
 
@@ -313,7 +316,8 @@ namespace Unity.Robotics.ROSTCPConnector
 
             while (bytesRemaining > 0)
             {
-                int bytesRead = networkStream.Read(readBuffer, totalBytesRead, Math.Min(2048, bytesRemaining));
+                // Read the minimum of the bytes remaining, or the designated byteChunkToRead in segments until none remain
+                int bytesRead = networkStream.Read(readBuffer, totalBytesRead, Math.Min(byteChunkToRead, bytesRemaining));
                 totalBytesRead += bytesRead;
                 bytesRemaining -= bytesRead;
             }

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -311,7 +311,7 @@ namespace Unity.Robotics.ROSTCPConnector
             int bytesRemaining = full_message_size;
             int totalBytesRead = 0;
 
-            while (networkStream.DataAvailable && bytesRemaining > 0)
+            while (bytesRemaining > 0)
             {
                 int bytesRead = networkStream.Read(readBuffer, totalBytesRead, Math.Min(2048, bytesRemaining));
                 totalBytesRead += bytesRead;

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -150,9 +150,7 @@ namespace Unity.Robotics.ROSTCPConnector
             try
             {
                 string serviceName;
-                var messageContents = await ReadMessageContents(networkStream);
-                var topicName = messageContents.Item1;
-                var content = messageContents.Item2;
+                (string topicName, byte[] content) = await ReadMessageContents(networkStream);
                 serviceResponse.Deserialize(content, 0);
             }
             catch (Exception e)
@@ -269,9 +267,7 @@ namespace Unity.Robotics.ROSTCPConnector
 
             SubscriberCallback subs;
 
-            var messageContents = await ReadMessageContents(networkStream);
-            var topicName = messageContents.Item1;
-            var content = messageContents.Item2;
+            (string topicName, byte[] content) = await ReadMessageContents(networkStream);
 
             if (!subscribers.TryGetValue(topicName, out subs))
                 return; // not interested in this topic

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -313,7 +313,7 @@ namespace Unity.Robotics.ROSTCPConnector
 
             while (networkStream.DataAvailable && bytesRemaining > 0)
             {
-                int bytesRead = networkStream.Read(readBuffer, totalBytesRead, bytesRemaining);
+                int bytesRead = networkStream.Read(readBuffer, totalBytesRead, Math.Min(2048, bytesRemaining));
                 totalBytesRead += bytesRead;
                 bytesRemaining -= bytesRead;
             }


### PR DESCRIPTION
Re: [https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/101](https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/101)

- `networkStream.DataAvailable` doesn't ensure that the sender has finished sending everything, just that there's nothing left in the read buffer, afaik. This was causing reads to end unexpectedly early for larger messages such as images.
- Reading the data stream in chunks instead of all at once