### PR TITLE
Laurie/keep incoming connection

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Editor/ROSSettingsEditor.cs
+++ b/com.unity.robotics.ros-tcp-connector/Editor/ROSSettingsEditor.cs
@@ -66,6 +66,10 @@ namespace Unity.Robotics.ROSTCPConnector.Editor
                 new GUIContent("Max Read retries",
                     "While waiting to read a full message, check this many times before giving up."),
                 prefab.awaitDataReadRetry);
+            prefab.timeoutOnIdle = EditorGUILayout.FloatField(
+                new GUIContent("Timeout on idle (seconds)",
+                    "If no messages have been sent for this long, close the connection."),
+                prefab.timeoutOnIdle);
 
             if (GUI.changed)
             {

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -292,6 +292,12 @@ namespace Unity.Robotics.ROSTCPConnector
                 float frameLimitRealTimestamp = Time.realtimeSinceStartup + 0.1f;
                 while (networkStream.DataAvailable && Time.realtimeSinceStartup < frameLimitRealTimestamp)
                 {
+                    if (!Application.isPlaying)
+                    {
+                        networkStream.Close();
+                        return;
+                    }
+
                     (string topicName, byte[] content) = await ReadMessageContents(networkStream);
                     lastDataReceivedRealTimestamp = Time.realtimeSinceStartup;
 

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -278,6 +278,10 @@ namespace Unity.Robotics.ROSTCPConnector
             if (!networkStream.CanRead)
                 return;
 
+            byte[] timeoutBytes = new byte[4];
+            networkStream.Read(timeoutBytes, 0, 4);
+            float timeout = BitConverter.ToSingle(timeoutBytes, 0);
+
             SubscriberCallback subs;
 
             float lastDataReceivedRealTimestamp = 0;
@@ -319,7 +323,7 @@ namespace Unity.Robotics.ROSTCPConnector
                 }
                 await Task.Yield();
             }
-            while (Time.realtimeSinceStartup < lastDataReceivedRealTimestamp + 15);
+            while (Time.realtimeSinceStartup < lastDataReceivedRealTimestamp + timeout);
             networkStream.Close();
         }
 

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -39,6 +39,9 @@ namespace Unity.Robotics.ROSTCPConnector
         [Tooltip("While waiting to read a full message, check this many times before giving up.")]
         public int awaitDataReadRetry = 10;
 
+        [Tooltip("Close connection if nothing has been sent for this long (seconds).")]
+        public float timeoutOnIdle = 10;
+
         static object _lock = new object(); // sync lock 
         static List<Task> activeConnectionTasks = new List<Task>(); // pending connections
 
@@ -278,10 +281,6 @@ namespace Unity.Robotics.ROSTCPConnector
             if (!networkStream.CanRead)
                 return;
 
-            byte[] timeoutBytes = new byte[4];
-            networkStream.Read(timeoutBytes, 0, 4);
-            float timeout = BitConverter.ToSingle(timeoutBytes, 0);
-
             SubscriberCallback subs;
 
             float lastDataReceivedRealTimestamp = 0;
@@ -329,7 +328,7 @@ namespace Unity.Robotics.ROSTCPConnector
                 }
                 await Task.Yield();
             } 
-            while (Time.realtimeSinceStartup < lastDataReceivedRealTimestamp + timeout); // time out if idle too long.
+            while (Time.realtimeSinceStartup < lastDataReceivedRealTimestamp + timeoutOnIdle); // time out if idle too long.
             networkStream.Close();
         }
 

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -294,13 +294,6 @@ namespace Unity.Robotics.ROSTCPConnector
                     if (!subscribers.TryGetValue(topicName, out subs))
                         continue; // not interested in this topic
 
-                    if (subs.messageConstructor == null)
-                    {
-                        if (hudPanel != null)
-                            hudPanel.SetLastMessageRaw(topicName, content);
-                        return;
-                    }
-
                     Message msg = (Message)subs.messageConstructor.Invoke(new object[0]);
                     msg.Deserialize(content, 0);
 

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -322,8 +322,8 @@ namespace Unity.Robotics.ROSTCPConnector
                     }
                 }
                 await Task.Yield();
-            }
-            while (Time.realtimeSinceStartup < lastDataReceivedRealTimestamp + timeout);
+            } 
+            while (Time.realtimeSinceStartup < lastDataReceivedRealTimestamp + timeout); // time out if idle too long.
             networkStream.Close();
         }
 


### PR DESCRIPTION
We keep incoming (subscribe) connections from the endpoint to Unity alive and send multiple messages instead of closing the connection and opening a new one every time, which makes it much more robust under heavy traffic conditions.
Tested by playing a rosbag.