### PR TITLE
Laurie/connection status hud

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/HUDPanel.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/HUDPanel.cs
@@ -112,18 +112,20 @@ namespace Unity.Robotics.ROSTCPConnector
 
         Color GetConnectionColor(float elapsedTime)
         {
-            Color bright = new Color(1, 1, 0.5f);
-            Color mid = new Color(0, 1, 1);
-            Color dark = new Color(0, 0.5f, 1);
+            var bright = new Color(1, 1, 0.5f);
+            var mid = new Color(0, 1, 1);
+            var dark = new Color(0, 0.5f, 1);
+            const float brightDuration = 0.03f;
+            const float fadeToDarkDuration = 1.0f;
 
             if (!ROSConnection.instance.HasConnectionThread)
                 return Color.gray;
             if (ROSConnection.instance.HasConnectionError)
                 return Color.red;
-            if (elapsedTime > 0.03f)
-                return Color.Lerp(mid, dark, elapsedTime);
-            else
+            if (elapsedTime <= brightDuration)
                 return bright;
+            else
+                return Color.Lerp(mid, dark, elapsedTime/fadeToDarkDuration);
         }
 
         void OnGUI()

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/HUDPanel.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/HUDPanel.cs
@@ -146,7 +146,7 @@ namespace Unity.Robotics.ROSTCPConnector
 
             if (!ROSConnection.instance.HasConnectionThread)
             {
-                host = GUILayout.TextField(host, m_ContentStyle);
+                ROSConnection.instance.RosIPAddress = GUILayout.TextField(ROSConnection.instance.RosIPAddress);
                 GUILayout.EndHorizontal();
                 GUILayout.Label("(Not connected)");
                 if (GUILayout.Button("Connect"))

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/HUDPanel.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/HUDPanel.cs
@@ -138,9 +138,9 @@ namespace Unity.Robotics.ROSTCPConnector
             GUILayout.BeginHorizontal();
             Color baseColor = GUI.color;
             GUI.color = GetConnectionColor(Time.realtimeSinceStartup - m_LastMessageReceivedRealtime);
-            GUILayout.Label("<", m_LabelStyle, GUILayout.Width(10));
+            GUILayout.Label("\u25C0", m_LabelStyle, GUILayout.Width(10));
             GUI.color = GetConnectionColor(Time.realtimeSinceStartup - m_LastMessageSentRealtime);
-            GUILayout.Label(">", m_LabelStyle, GUILayout.Width(10));
+            GUILayout.Label("\u25B6", m_LabelStyle, GUILayout.Width(15));
             GUI.color = baseColor;
             GUILayout.Label("ROS IP: ", m_LabelStyle, GUILayout.Width(100));
 

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/HUDPanel.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/HUDPanel.cs
@@ -22,20 +22,24 @@ namespace Unity.Robotics.ROSTCPConnector
 
         MessageViewState m_LastMessageSent;
         string m_LastMessageSentMeta = "None";
+        float m_LastMessageSentRealtime;
 
         public void SetLastMessageSent(string topic, Message message)
         {
             m_LastMessageSent = new MessageViewState() { label = "Last Message Sent:", message = message };
             m_LastMessageSentMeta = $"{topic} (time: {System.DateTime.Now.TimeOfDay})";
+            m_LastMessageSentRealtime = Time.realtimeSinceStartup;
         }
 
         MessageViewState m_LastMessageReceived;
         string m_LastMessageReceivedMeta = "None";
+        float m_LastMessageReceivedRealtime;
 
         public void SetLastMessageReceived(string topic, Message message)
         {
             m_LastMessageReceived = new MessageViewState() { label = "Last Message Received:", message = message };
             m_LastMessageReceivedMeta = $"{topic} (time: {System.DateTime.Now.TimeOfDay})";
+            m_LastMessageReceivedRealtime = Time.realtimeSinceStartup;
         }
 
         List<MessageViewState> activeServices = new List<MessageViewState>();
@@ -106,17 +110,53 @@ namespace Unity.Robotics.ROSTCPConnector
             m_ScrollRect = new Rect();
         }
 
+        Color GetConnectionColor(float elapsedTime)
+        {
+            Color bright = new Color(1, 1, 0.5f);
+            Color mid = new Color(0, 1, 1);
+            Color dark = new Color(0, 0.5f, 1);
+
+            if (!ROSConnection.instance.HasConnectionThread)
+                return Color.gray;
+            if (ROSConnection.instance.HasConnectionError)
+                return Color.red;
+            if (elapsedTime > 0.03f)
+                return Color.Lerp(mid, dark, elapsedTime);
+            else
+                return bright;
+        }
+
         void OnGUI()
         {
             if (!isEnabled)
                 return;
 
             // Initialize main HUD
-            GUILayout.BeginVertical("box");
+            GUILayout.BeginVertical(GUI.skin.box, GUILayout.Width(300));
 
             // ROS IP Setup
-            GUILayout.Label("ROS IP:", m_LabelStyle);
-            GUILayout.Label(host, m_ContentStyle);
+            GUILayout.BeginHorizontal();
+            Color baseColor = GUI.color;
+            GUI.color = GetConnectionColor(Time.realtimeSinceStartup - m_LastMessageReceivedRealtime);
+            GUILayout.Label("<", m_LabelStyle, GUILayout.Width(10));
+            GUI.color = GetConnectionColor(Time.realtimeSinceStartup - m_LastMessageSentRealtime);
+            GUILayout.Label(">", m_LabelStyle, GUILayout.Width(10));
+            GUI.color = baseColor;
+            GUILayout.Label("ROS IP: ", m_LabelStyle, GUILayout.Width(100));
+
+            if (!ROSConnection.instance.HasConnectionThread)
+            {
+                host = GUILayout.TextField(host, m_ContentStyle);
+                GUILayout.EndHorizontal();
+                GUILayout.Label("(Not connected)");
+                if (GUILayout.Button("Connect"))
+                    ROSConnection.instance.Connect();
+            }
+            else
+            {
+                GUILayout.Label(host, m_ContentStyle);
+                GUILayout.EndHorizontal();
+            }
 
             // Last message sent
             GUILayout.Label("Last Message Sent:", m_LabelStyle);

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -231,8 +231,6 @@ namespace Unity.Robotics.ROSTCPConnector
         {
             m_RosIPAddress = ipAddress;
             m_RosPort = port;
-            if (m_HudPanel != null)
-                m_HudPanel.host = $"{ipAddress}:{port}";
             Connect();
         }
 
@@ -240,6 +238,9 @@ namespace Unity.Robotics.ROSTCPConnector
         {
             if (!IPFormatIsCorrect(m_RosIPAddress))
                 Debug.LogError("ROS IP address is not correct");
+
+            if (m_HudPanel != null)
+                m_HudPanel.host = $"{m_RosIPAddress}:{m_RosPort}";
 
             m_ConnectionThreadCancellation = new CancellationTokenSource();
             Task.Run(() => ConnectionThread(m_RosIPAddress, m_RosPort, m_NetworkTimeoutSeconds, m_KeepaliveTime, (int)(m_SleepTimeSeconds*1000.0f), m_OutgoingMessages, m_IncomingMessages, m_ConnectionThreadCancellation.Token));

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -69,6 +69,11 @@ namespace Unity.Robotics.ROSTCPConnector
         ConcurrentQueue<Tuple<string, byte[]>> m_IncomingMessages = new ConcurrentQueue<Tuple<string, byte[]>>();
         CancellationTokenSource m_ConnectionThreadCancellation;
 
+        public bool HasConnectionThread => m_ConnectionThreadCancellation != null;
+
+        static bool m_HasConnectionError = false;
+        public bool HasConnectionError => m_HasConnectionError;
+
         static float s_RealTimeSinceStartup = 0.0f;// only the main thread can access Time.realTimeSinceStartup, so make a copy here
 
         readonly object m_ServiceRequestLock = new object();

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -248,7 +248,8 @@ namespace Unity.Robotics.ROSTCPConnector
 
         public void Disconnect()
         {
-            m_ConnectionThreadCancellation.Cancel();
+            if(m_ConnectionThreadCancellation != null)
+                m_ConnectionThreadCancellation.Cancel();
             m_ConnectionThreadCancellation = null;
         }
 


### PR DESCRIPTION
Added connection status lights to the HUD - blue if ok, bright blue if actively sending, red if there's a problem.
Also, if you turn off "Connect on Startup", there's a field where you can set your IP and a button to connect.

Merge alongside https://github.com/Unity-Technologies/ROS-TCP-Endpoint/pull/58