### PR TITLE
Bugfix/sending unknown type

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
+++ b/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
@@ -17,12 +17,15 @@ Upgrade the TestRosTcpConnector project to use Unity LTS version 2020.3.11f1
 Add the Ros Tcp Connector assembly to support Universal Windows Platform
 
 ### Changed
+- Publishing a message to an unregistered topic will show an error.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+  - Fixed the issue when queuing a message fails if the type is unspecified in compile type.
+
 
 ## [0.5.0-preview] - 2021-07-15
 

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -726,7 +726,12 @@ namespace Unity.Robotics.ROSTCPConnector
         {
             if (!rosTopicName.StartsWith("__"))
             {
-                m_Publishers[rosTopicName] = MessageRegistry.GetRosMessageName<T>();
+                if (!m_Publishers.ContainsKey(rosTopicName))
+                {
+                    Debug.LogError($"Can't publish a message to an unregistered topic '{rosTopicName}'");
+                    return;
+                }
+
                 if (m_HudPanel != null)
                     m_HudPanel.SetLastMessageSent(rosTopicName, message);
             }


### PR DESCRIPTION
## Proposed change(s)
Fixing the issue when publishing a message before the connection is established and queuing the message may fail if the message type is unknown in compile time.
The reason was that GetRosMessageName<T>() was null and corrupted the m_Publishers dictionary. 

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)
The issue was identified when testing the RoboticsSensor package as the PublishToRos() sends generic messages.

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification


### Test Configuration:
- Unity Version: [e.g. Unity 2021.1.11f1]
- Unity machine OS + version: macOS 10.15.7
- ROS machine OS + version: Ubuntu 20.04, ROS Noetic
- ROS–Unity communication: VM

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate