### PR TITLE
Removing stale "M" prefix from Header.ToString

### DIFF
--- a/.yamato/yamato-config.yml
+++ b/.yamato/yamato-config.yml
@@ -1,7 +1,7 @@
 name: Connector Unit Tests
 agent:
     type: Unity::VM
-    image: robotics/ci-ubuntu20:latest
+    image: robotics/ci-ubuntu20:v0.1.0-795910
     flavor: i1.large
 variables:
     PATH: /root/.local/bin:/home/bokken/bin:/home/bokken/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/sbin:/home/bokken/.npm-global/bin

--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/HandwrittenMessages/msg/HeaderMsg.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/HandwrittenMessages/msg/HeaderMsg.cs
@@ -81,7 +81,7 @@ namespace RosMessageTypes.Std
 
         public override string ToString()
         {
-            return "MHeader: " +
+            return "Header: " +
 #if !ROS2
             "\nseq: " + seq.ToString() +
 #endif          


### PR DESCRIPTION
User from a Robotics hub issue notices that we have a dangling M prefix here that isn't needed.  Removing from the string.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/274

### Types of change(s)

- [x] Other (Stale ToString fix)

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)