### PR TITLE
Fix DurationMsg. Add SerializeTo method.

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/HandwrittenMessages/msg/DurationMsg.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/HandwrittenMessages/msg/DurationMsg.cs
@@ -60,6 +60,12 @@ namespace RosMessageTypes.BuiltinInterfaces
             deserializer.Read(out this.nanosec);
         }
 
+        public override void SerializeTo(MessageSerializer serializer)
+        {
+            serializer.Write(this.sec);
+            serializer.Write(this.nanosec);
+        }
+
         public override string ToString()
         {
             return "Duration: " +


### PR DESCRIPTION
## Proposed change(s)

Describe the changes made in this PR.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Fixes bug with DurationMsg missing override to SerializeTo method. First reported by a user in a forum [post](https://forum.unity.com/threads/notimplementedexception-thrown-when-using-jointtrajectory-jointtrajectorypoint-messages.1157531/) then created an issue AIRO-1163.

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments