### PR TITLE
Adding an API to convert transform in local coordinate frame from Unity to other coordinate frames.

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
+++ b/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
@@ -16,10 +16,11 @@ Upgrade the TestRosTcpConnector project to use Unity LTS version 2020.3.11f1
 
 ### Added
 
-Add the Ros Tcp Connector assembly to support Universal Windows Platform
+  - Add the Ros Tcp Connector assembly to support Universal Windows Platform
 
-Added the CameraInfoGenerator that takes a Unity Camera and a provided HeaderMsg, generate a corresponding CameraInfoMsg, see:
-[CameraInfo Generator](https://github.com/Unity-Technologies/ROS-TCP-Connector/issues/133)
+  - Added the CameraInfoGenerator that takes a Unity Camera and a provided HeaderMsg, generate a corresponding CameraInfoMsg, see:
+    [CameraInfo Generator](https://github.com/Unity-Technologies/ROS-TCP-Connector/issues/133)
+  - Added API to create TransformMsg using local frame of a transform in Unity
 
 ### Changed
 - Publishing a message to an unregistered topic will show an error.

--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
@@ -119,6 +119,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         {
             return new TransformMsg(new Vector3<C>(transform.position), new Quaternion<C>(transform.rotation));
         }
+        
         public static TransformMsg ToLocal<C>(this Transform transform) where C : ICoordinateSpace, new()
         {
             return new TransformMsg(new Vector3<C>(transform.localPosition), new Quaternion<C>(transform.localRotation));

--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
@@ -119,6 +119,10 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         {
             return new TransformMsg(new Vector3<C>(transform.position), new Quaternion<C>(transform.rotation));
         }
+        public static TransformMsg ToLocal<C>(this Transform transform) where C : ICoordinateSpace, new()
+        {
+            return new TransformMsg(new Vector3<C>(transform.localPosition), new Quaternion<C>(transform.localRotation));
+        }
 
         public static Vector3 From(this PointMsg self, CoordinateSpaceSelection selection)
         {

--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
@@ -119,7 +119,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         {
             return new TransformMsg(new Vector3<C>(transform.position), new Quaternion<C>(transform.rotation));
         }
-        
+
         public static TransformMsg ToLocal<C>(this Transform transform) where C : ICoordinateSpace, new()
         {
             return new TransformMsg(new Vector3<C>(transform.localPosition), new Quaternion<C>(transform.localRotation));

--- a/com.unity.robotics.ros-tcp-connector/Tests/Runtime/ROSGeometryTests.cs
+++ b/com.unity.robotics.ros-tcp-connector/Tests/Runtime/ROSGeometryTests.cs
@@ -18,17 +18,17 @@ namespace Tests.Runtime
             child.transform.localRotation = new Quaternion(.3f, .4f, .5f, 1);
 
             var testMsg = child.transform.ToLocal<FLU>();
-            var fluPosition = new Vector3(.2f, .3f, .5f).To<FLU>();
-            var fluRotation = new Quaternion(.3f, .4f, .5f, 1).To<FLU>();
+            var fluPosition = child.transform.localPosition.To<FLU>();
+            var fluRotation = child.transform.localRotation.To<FLU>();
             Assert.IsNotNull(testMsg);
-            Assert.AreApproximatelyEqual(fluPosition.x,(float)testMsg.translation.x);
-            Assert.AreApproximatelyEqual(fluPosition.y,(float)testMsg.translation.y);
-            Assert.AreApproximatelyEqual(fluPosition.z,(float)testMsg.translation.z);
+            Assert.AreApproximatelyEqual(fluPosition.x, (float)testMsg.translation.x);
+            Assert.AreApproximatelyEqual(fluPosition.y, (float)testMsg.translation.y);
+            Assert.AreApproximatelyEqual(fluPosition.z, (float)testMsg.translation.z);
             fluRotation.Normalize();
-            Assert.AreApproximatelyEqual(fluRotation.x,(float)testMsg.rotation.x);
-            Assert.AreApproximatelyEqual(fluRotation.y,(float)testMsg.rotation.y);
-            Assert.AreApproximatelyEqual(fluRotation.z,(float)testMsg.rotation.z);
-            Assert.AreApproximatelyEqual(fluRotation.w,(float)testMsg.rotation.w);
+            Assert.AreApproximatelyEqual(fluRotation.x, (float)testMsg.rotation.x);
+            Assert.AreApproximatelyEqual(fluRotation.y, (float)testMsg.rotation.y);
+            Assert.AreApproximatelyEqual(fluRotation.z, (float)testMsg.rotation.z);
+            Assert.AreApproximatelyEqual(fluRotation.w, (float)testMsg.rotation.w);
         }
     }
 }

--- a/com.unity.robotics.ros-tcp-connector/Tests/Runtime/ROSGeometryTests.cs
+++ b/com.unity.robotics.ros-tcp-connector/Tests/Runtime/ROSGeometryTests.cs
@@ -24,7 +24,6 @@ namespace Tests.Runtime
             Assert.AreApproximatelyEqual(fluPosition.x, (float)testMsg.translation.x);
             Assert.AreApproximatelyEqual(fluPosition.y, (float)testMsg.translation.y);
             Assert.AreApproximatelyEqual(fluPosition.z, (float)testMsg.translation.z);
-            fluRotation.Normalize();
             Assert.AreApproximatelyEqual(fluRotation.x, (float)testMsg.rotation.x);
             Assert.AreApproximatelyEqual(fluRotation.y, (float)testMsg.rotation.y);
             Assert.AreApproximatelyEqual(fluRotation.z, (float)testMsg.rotation.z);

--- a/com.unity.robotics.ros-tcp-connector/Tests/Runtime/ROSGeometryTests.cs
+++ b/com.unity.robotics.ros-tcp-connector/Tests/Runtime/ROSGeometryTests.cs
@@ -1,0 +1,34 @@
+using NUnit.Framework;
+using Unity.Robotics.ROSTCPConnector.ROSGeometry;
+using UnityEngine;
+using Assert = UnityEngine.Assertions.Assert;
+
+namespace Tests.Runtime
+{
+    public class RosGeometryTests
+    {
+        [Test]
+        public void TransfromtoLocal_ChildObjectTransform_LocalTransform()
+        {
+            GameObject parent = new GameObject();
+            parent.transform.position = new Vector3(1, 1, 1);
+            GameObject child = new GameObject();
+            child.transform.parent = parent.transform;
+            child.transform.localPosition = new Vector3(.2f, .3f, .5f);
+            child.transform.localRotation = new Quaternion(.3f, .4f, .5f, 1);
+
+            var testMsg = child.transform.ToLocal<FLU>();
+            var fluPosition = new Vector3(.2f, .3f, .5f).To<FLU>();
+            var fluRotation = new Quaternion(.3f, .4f, .5f, 1).To<FLU>();
+            Assert.IsNotNull(testMsg);
+            Assert.AreApproximatelyEqual(fluPosition.x,(float)testMsg.translation.x);
+            Assert.AreApproximatelyEqual(fluPosition.y,(float)testMsg.translation.y);
+            Assert.AreApproximatelyEqual(fluPosition.z,(float)testMsg.translation.z);
+            fluRotation.Normalize();
+            Assert.AreApproximatelyEqual(fluRotation.x,(float)testMsg.rotation.x);
+            Assert.AreApproximatelyEqual(fluRotation.y,(float)testMsg.rotation.y);
+            Assert.AreApproximatelyEqual(fluRotation.z,(float)testMsg.rotation.z);
+            Assert.AreApproximatelyEqual(fluRotation.w,(float)testMsg.rotation.w);
+        }
+    }
+}

--- a/com.unity.robotics.ros-tcp-connector/Tests/Runtime/ROSGeometryTests.cs.meta
+++ b/com.unity.robotics.ros-tcp-connector/Tests/Runtime/ROSGeometryTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5ab49b935f9f43f78afcce9ba3e0b9d9
+timeCreated: 1630086708


### PR DESCRIPTION
## Proposed change(s)

Adding API to convert transform to Transform msg using local rotation and local translation.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment.

### Test Configuration:
- Unity Version: [e.g. Unity 2020.2.0f1]
- MacOS 11.5


## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments