### PR TITLE
Laurie/image msg optimizations

### DIFF
--- a/com.unity.robotics.message-visualizations/Runtime/DefaultVisualizers/Sensor/ImageDefaultVisualizer.cs
+++ b/com.unity.robotics.message-visualizations/Runtime/DefaultVisualizers/Sensor/ImageDefaultVisualizer.cs
@@ -26,7 +26,7 @@ public class ImageDefaultVisualizer : TextureVisualizer<ImageMsg>
                 GUILayout.BeginHorizontal();
                 if (message.EncodingRequiresBGRConversion())
                     m_ConvertBgr = GUILayout.Toggle(m_ConvertBgr, "From BGR");
-                if (message.EncodingRequiresBGRConversion())
+                if (message.IsBayerEncoded())
                     m_Debayer = GUILayout.Toggle(m_Debayer, "Debayer");
                 m_FlipY = GUILayout.Toggle(m_FlipY, "Flip Y");
                 GUILayout.EndHorizontal();

--- a/com.unity.robotics.message-visualizations/Runtime/DefaultVisualizers/Sensor/ImageDefaultVisualizer.cs
+++ b/com.unity.robotics.message-visualizations/Runtime/DefaultVisualizers/Sensor/ImageDefaultVisualizer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using RosMessageTypes.Sensor;
 using Unity.Robotics.MessageVisualizers;
 using Unity.Robotics.ROSTCPConnector.MessageGeneration;
@@ -6,33 +7,119 @@ using UnityEngine;
 
 public class ImageDefaultVisualizer : TextureVisualizer<ImageMsg>
 {
-    bool m_ConvertBgr = true;
+    [SerializeField]
     bool m_Debayer = true;
-    bool m_FlipY = true;
 
     public override Texture2D CreateTexture(ImageMsg message)
     {
-        return message.data.Length > 0 ? message.ToTexture2D(m_ConvertBgr, m_Debayer, m_FlipY) : null;
+        return message.data.Length > 0 ? message.ToTexture2D(m_Debayer) : null;
     }
 
-    public override Action CreateGUI(ImageMsg message, MessageMetadata meta, Texture2D tex)
+    protected override IVisual CreateVisual()
     {
-        return () =>
+        return new ImageVisual(this);
+    }
+
+    public class ImageVisual : ITextureVisual
+    {
+        // cache the original image height, width and encoding here so that we if we have to debayer the image (which resizes it) we still show the real values
+        int m_Width;
+        int m_Height;
+        string m_Encoding;
+        bool m_Debayer;
+
+        ImageDefaultVisualizer m_Factory;
+
+        Action m_GUIAction;
+        // after anyone asks for it, we cache the properly processed texture here
+        Texture2D m_Texture2D;
+        // if nobody asks for the proper texture, we generate CheapTexture2D: this is just
+        // the raw bytes from the message, dumped into a texture.
+        // cheap to make but will look wrong without a special shader
+        Texture2D m_CheapTexture2D;
+        Material m_CheapTextureMaterial;
+        List<Action<Texture2D>> m_OnChangeCallbacks = new List<Action<Texture2D>>();
+
+        public void ListenForTextureChange(Action<Texture2D> callback)
+        {
+            m_OnChangeCallbacks.Add(callback);
+        }
+
+        public ImageVisual(ImageDefaultVisualizer factory)
+        {
+            m_Factory = factory;
+            m_Debayer = factory.m_Debayer;
+            m_CheapTextureMaterial = new Material(Shader.Find("Unlit/ImageMsg"));
+        }
+
+        public virtual void AddMessage(Message message, MessageMetadata meta)
+        {
+            if (!MessageVisualizationUtils.AssertMessageType<ImageMsg>(message, meta))
+                return;
+
+            this.message = (ImageMsg)message;
+            this.meta = meta;
+            m_Texture2D = null;
+            m_CheapTexture2D = null;
+            m_GUIAction = null;
+            m_Width = (int)this.message.width;
+            m_Height = (int)this.message.height;
+            m_Encoding = this.message.encoding;
+            //m_CheapTextureMaterial.SetFloat("_gray", this.message.GetNumChannels() == 1 ? 1.0f : 0.0f);
+            m_CheapTextureMaterial.SetFloat("_convertBGR", this.message.EncodingRequiresBGRConversion() ? 1.0f : 0.0f);
+
+            // if anyone wants to know about the texture, make sure it's updated for them
+            if (m_OnChangeCallbacks.Count > 0)
+                GetTexture();
+        }
+
+        public ImageMsg message { get; private set; }
+
+        public MessageMetadata meta { get; private set; }
+
+        public bool hasDrawing => false;
+        public bool hasAction => m_GUIAction != null;
+
+        public void OnGUI()
         {
             message.header.GUI();
-            GUILayout.Label($"{message.height}x{message.width}, encoding: {message.encoding}");
+            GUILayout.Label($"{m_Height}x{m_Width}, encoding: {m_Encoding}");
             if (message.data.Length > 0)
             {
                 GUILayout.BeginHorizontal();
-                if (message.EncodingRequiresBGRConversion())
-                    m_ConvertBgr = GUILayout.Toggle(m_ConvertBgr, "From BGR");
-                if (message.IsBayerEncoded())
+                if (m_Encoding.StartsWith("bayer"))
                     m_Debayer = GUILayout.Toggle(m_Debayer, "Debayer");
-                m_FlipY = GUILayout.Toggle(m_FlipY, "Flip Y");
                 GUILayout.EndHorizontal();
-            }
 
-            tex.GUITexture();
-        };
+                if (m_Texture2D != null || m_Debayer)
+                {
+                    // if we already generated the "real" texture, just use that
+                    GetTexture().GUITexture();
+                }
+                else
+                {
+                    if (m_CheapTexture2D == null)
+                    {
+                        m_CheapTexture2D = message.ToTexture2D(m_Debayer, convertBGR: false, flipY: false);
+                    }
+                    m_CheapTexture2D.GUITexture(m_CheapTextureMaterial);
+                }
+            }
+        }
+
+        public Texture2D GetTexture()
+        {
+            if (m_Texture2D == null)
+            {
+                m_Texture2D = (message != null && message.data.Length > 0) ? message.ToTexture2D(m_Debayer) : null;
+
+                foreach (Action<Texture2D> callback in m_OnChangeCallbacks)
+                    callback(m_Texture2D);
+            }
+            return m_Texture2D;
+        }
+
+        public void DeleteDrawing() { }
+        public void CreateDrawing() { }
     }
 }

--- a/com.unity.robotics.message-visualizations/Runtime/DefaultVisualizers/Sensor/ImageDefaultVisualizer.cs
+++ b/com.unity.robotics.message-visualizations/Runtime/DefaultVisualizers/Sensor/ImageDefaultVisualizer.cs
@@ -7,11 +7,12 @@ using UnityEngine;
 public class ImageDefaultVisualizer : TextureVisualizer<ImageMsg>
 {
     bool m_ConvertBgr = true;
+    bool m_Debayer = true;
     bool m_FlipY = true;
 
     public override Texture2D CreateTexture(ImageMsg message)
     {
-        return message.data.Length > 0 ? message.ToTexture2D(m_ConvertBgr, m_FlipY) : null;
+        return message.data.Length > 0 ? message.ToTexture2D(m_ConvertBgr, m_Debayer, m_FlipY) : null;
     }
 
     public override Action CreateGUI(ImageMsg message, MessageMetadata meta, Texture2D tex)
@@ -23,7 +24,10 @@ public class ImageDefaultVisualizer : TextureVisualizer<ImageMsg>
             if (message.data.Length > 0)
             {
                 GUILayout.BeginHorizontal();
-                if (!message.encoding.Contains("1") && !message.encoding.Contains("mono") && !message.encoding.Contains("bayer")) m_ConvertBgr = GUILayout.Toggle(m_ConvertBgr, "From BGR");
+                if (message.EncodingRequiresBGRConversion())
+                    m_ConvertBgr = GUILayout.Toggle(m_ConvertBgr, "From BGR");
+                if (message.EncodingRequiresBGRConversion())
+                    m_Debayer = GUILayout.Toggle(m_Debayer, "Debayer");
                 m_FlipY = GUILayout.Toggle(m_FlipY, "Flip Y");
                 GUILayout.EndHorizontal();
             }

--- a/com.unity.robotics.message-visualizations/Runtime/DefaultVisualizers/Sensor/ImageDefaultVisualizer.cs
+++ b/com.unity.robotics.message-visualizations/Runtime/DefaultVisualizers/Sensor/ImageDefaultVisualizer.cs
@@ -19,6 +19,7 @@ public class ImageDefaultVisualizer : TextureVisualizer<ImageMsg>
         return () =>
         {
             message.header.GUI();
+            GUILayout.Label($"{message.height}x{message.width}, encoding: {message.encoding}");
             if (message.data.Length > 0)
             {
                 GUILayout.BeginHorizontal();
@@ -28,7 +29,6 @@ public class ImageDefaultVisualizer : TextureVisualizer<ImageMsg>
             }
 
             tex.GUITexture();
-            GUILayout.Label($"Height x Width: {message.height}x{message.width}\nEncoding: {message.encoding}");
         };
     }
 }

--- a/com.unity.robotics.message-visualizations/Runtime/Scripts/MessageVisualizationUtils.cs
+++ b/com.unity.robotics.message-visualizations/Runtime/Scripts/MessageVisualizationUtils.cs
@@ -204,10 +204,26 @@ namespace Unity.Robotics.MessageVisualizers
         public static void GUITexture(this Texture2D tex)
         {
             // TODO: Rescale/recenter image based on window height/width
-            if (tex != null)
+            if (tex == null)
+                return;
+
+            var origRatio = tex.width / (float)tex.height;
+            UnityEngine.GUI.Box(GUILayoutUtility.GetAspectRect(origRatio), tex);
+        }
+
+        public static void GUITexture(this Texture2D tex, Material material)
+        {
+            if (tex == null)
+                return;
+            var origRatio = tex.width / (float)tex.height;
+            Rect textureRect = GUILayoutUtility.GetAspectRect(origRatio);
+            if (Event.current.type == EventType.Repaint)
             {
-                var origRatio = tex.width / (float)tex.height;
-                UnityEngine.GUI.Box(GUILayoutUtility.GetAspectRect(origRatio), tex);
+                Graphics.DrawTexture(textureRect, tex, material);
+            }
+            else
+            {
+                UnityEngine.GUI.Box(textureRect, tex);
             }
         }
 

--- a/com.unity.robotics.message-visualizations/Runtime/Scripts/VisualizationTopicsTabEntry.cs
+++ b/com.unity.robotics.message-visualizations/Runtime/Scripts/VisualizationTopicsTabEntry.cs
@@ -55,9 +55,19 @@ namespace Unity.Robotics.MessageVisualizers
         {
             m_TopicState = topicState;
             if (save.HasRect && save.Rect.width > 0 && save.Rect.height > 0)
+            {
                 m_VisualWindow = new HudWindow(save.Topic, save.Rect);
-            else
+            }
+            else if (save.ShowWindow)
+            {
                 m_VisualWindow = new HudWindow(save.Topic);
+            }
+
+            if (m_VisualWindow != null)
+            {
+                m_VisualWindow.SetOnGUI(DefaultWindowContents);
+                HudPanel.AddWindow(m_VisualWindow);
+            }
 
             SetVisualizing(save.ShowWindow, save.ShowDrawing);
         }

--- a/com.unity.robotics.message-visualizations/Runtime/Shaders.meta
+++ b/com.unity.robotics.message-visualizations/Runtime/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 97856a5dc6c298445abfcf7b6ba701a0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.robotics.message-visualizations/Runtime/Shaders/ImageMsg.shader
+++ b/com.unity.robotics.message-visualizations/Runtime/Shaders/ImageMsg.shader
@@ -1,0 +1,71 @@
+Shader "Unlit/ImageMsg"
+{
+    Properties
+    {
+        _MainTex("Texture", 2D) = "white" {}
+		[Toggle] _convertBGR("convert BGR", Float) = 0
+		[Toggle] _flipY("Flip Y", Float) = 1
+		[Toggle] _gray("Gray", Float) = 0
+    }
+	
+	SubShader
+	{
+		Tags { "Queue"="Overlay" "IgnoreProjector"="True" "RenderType"="Transparent" }
+		Lighting Off
+		Cull Off
+		ZTest Always
+		ZWrite Off
+		Fog { Mode Off }
+		
+		Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+			float _convertBGR;
+			float _flipY;
+			float _gray;
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(
+                    float4(v.vertex.x, v.vertex.y, v.vertex.z, 0)
+                );
+				o.uv = _flipY == 0? v.uv: float2(v.uv.x, 1-v.uv.y);
+				return o;
+			}
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                fixed4 color = tex2D(_MainTex, i.uv);
+				if(_gray > 0.5)
+					color = color.rrra;
+				else if(_convertBGR > 0.5)
+					color = color.bgra;
+                color.a = 1;
+                return color;
+            }
+			
+            ENDCG
+        }
+
+	}
+}

--- a/com.unity.robotics.message-visualizations/Runtime/Shaders/ImageMsg.shader.meta
+++ b/com.unity.robotics.message-visualizations/Runtime/Shaders/ImageMsg.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 79210c8cd34c373409ebb5855746ef15
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.robotics.ros-tcp-connector/Runtime/MessageGeneration/MessageExtensions.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/MessageGeneration/MessageExtensions.cs
@@ -153,8 +153,6 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
             return new ColorRGBAMsg(color.r, color.g, color.b, color.a);
         }
 
-        static byte[] s_ScratchSpace;
-
         /// <summary>
         /// Converts a byte array from BGR to RGB.
         /// </summary>
@@ -214,6 +212,8 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
             }
             return image.data;
         }
+
+        static byte[] s_ScratchSpace;
 
         static void ReverseInBlocks(byte[] array, int blockSize, int numBlocks)
         {

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/HudWindow.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/HudWindow.cs
@@ -28,6 +28,7 @@ namespace Unity.Robotics.ROSTCPConnector
             m_WindowID = HudPanel.GetNextWindowID();
             m_IsActive = true;
             m_AutoLayout = false;
+            m_WindowRect = rect;
         }
 
         public HudWindow(string title)


### PR DESCRIPTION
ImageMsg visualizer now has two texture processing paths: a fast GPU-optimized one for when you just need a visualization and a slower ("proper") one for when other systems request a Texture2D.