### PR TITLE
Allow adding ROS2 to different build targets

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
+++ b/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
@@ -34,6 +34,7 @@ Upgrade the TestRosTcpConnector project to use Unity LTS version 2020.3.11f1
 
   - Added the missing SerializeTo function for DurationMsg
 
+  - Allow switching protocol to ROS2 in different build targets (Standalone, WSA, etc.).
 
 ## [0.5.0-preview] - 2021-07-15
 

--- a/com.unity.robotics.ros-tcp-connector/Editor/ROSSettingsEditor.cs
+++ b/com.unity.robotics.ros-tcp-connector/Editor/ROSSettingsEditor.cs
@@ -71,12 +71,22 @@ namespace Unity.Robotics.ROSTCPConnector.Editor
                 m_SelectedProtocol = (RosProtocol)EditorGUILayout.EnumPopup("Protocol", m_SelectedProtocol);
                 if (m_SelectedProtocol == k_AlternateProtocol)
                 {
-                    List<string> allDefines = PlayerSettings.GetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone).Split(';').ToList();
+                    var buildTarget = EditorUserBuildSettings.activeBuildTarget;
+                    var buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
+
+                    List<string> allDefines = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup).Split(';').ToList();
                     if (m_SelectedProtocol == RosProtocol.ROS1)
+                    {
                         allDefines.Remove("ROS2");
+                        Debug.Log($"Removing 'ROS2' from the scripting define symbols for build target '{buildTargetGroup}'.");
+                    }
                     else
+                    {
                         allDefines.Add("ROS2");
-                    PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone, string.Join(";", allDefines));
+                        Debug.Log($"Adding 'ROS2' to the scripting define symbols for build target '{buildTargetGroup}'.");
+                    }
+
+                    PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, string.Join(";", allDefines));
                 }
             }
 


### PR DESCRIPTION
## Proposed change(s)
This is to fix the issue when the protocol in ROS Settings could only be modified for standalone build target.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)
https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/303
Ticket# AIRO-1187

Provide any relevant links here.

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification
Tested switching the ROS protocol to ROS1 and ROS2 manually through the ROS Settings window on Universal Windows Platform, as well as Windows and MacOS Standalone.

### Test Configuration:
- Unity Version: Unity 2020.3.13f1
- Unity machine OS + version: Windows 10 and Mac OS Catalina

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments