### PR TITLE
Airo 1210 fix dotnet format

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,5 +13,6 @@ jobs:
                   python-version: 3.7.x
             - uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: '3.1.x'
+                  dotnet-version: '6.0.x'
+                  include-prerelease: true
             - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,8 @@ repos:
 
 
 - repo: https://github.com/dotnet/format
-  rev: "7e343070a0355c86f72bdee226b5e19ffcbac931"
+  rev: v5.1.225507
   hooks:
       - id: dotnet-format
+        entry: dotnet-format whitespace
         args: [--folder, --include]

--- a/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
+++ b/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
@@ -40,6 +40,8 @@ Upgrade the TestRosTcpConnector project to use Unity LTS version 2020.3.11f1
 
   - Allow switching protocol to ROS2 in different build targets (Standalone, WSA, etc.).
 
+  - Fixed dotnet format
+
 ## [0.5.0-preview] - 2021-07-15
 
 ### Upgrade Notes


### PR DESCRIPTION
## Proposed change(s)

We are following ml-agent's fix in [PR](https://github.com/Unity-Technologies/ml-agents/pull/5528/files)
 "Pre-commit is using a version of dotnet and dotnet-format and has picked up a newer version of the utility that is not compatible with .NET 3.1 or 5.x -- it installs it's packages using dotnet tool install. This version's default entrypoint is also incompatible with our project structure, as the style and analyzer subcommands are now run by default and do not support the --folder option.

The entrypoint can be over-ridden to specify the whitespace module, which should match previous behavior."



### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

fix in [PR](https://github.com/Unity-Technologies/ml-agents/pull/5528/files) 
### Types of change(s)

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Tested with github workflow pre-commit.

### Test Configuration:
- Unity Version: [e.g. Unity 2020.2.0f1]
- Unity machine OS + version: [e.g. Windows 10]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Noetic]
- ROS–Unity communication: [e.g. Docker]

## Checklist
- [X] Ensured this PR is up-to-date with the `dev` branch
- [X] Created this PR to target the `dev` branch
- [X] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [X] Added tests that prove my fix is effective or that my feature works
- [X] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [X] Updated the documentation as appropriate

## Other comments