### PR TITLE
Update geometry

### DIFF
--- a/ROSGeometry.md
+++ b/ROSGeometry.md
@@ -43,7 +43,7 @@ Unity's standard Transform class also has a `To<C>()` extension method that retu
 
 # Internal details
 
-Some more detail about what's going on here: The core of the ROSGeometry package is the two generic structs, `Vector3<C>` and `Quaternion<C>`. The type parameter C here indicates the coordinate frame you're working in - either FLU, or RUF, or perhaps one of the more exotic frames such as NED (north, east, down) or ENU (east, north, up), used in aviation. In conversions between RUF and geographical coordinate systems, such as NED and ENU, the east direction is equivalent to the z-axis (forward) in RUF.
+Some more detail about what's going on here: The core of the ROSGeometry package is the two generic structs, `Vector3<C>` and `Quaternion<C>`. The type parameter C here indicates the coordinate frame you're working in - either FLU, or RUF, or perhaps one of the more exotic frames such as NED (north, east, down) or ENU (east, north, up), used in aviation.
 
 These are fully-fledged Vector3 and Quaternion classes, so if you want, you can work with them directly to perform geometric operations in an arbitrary coordinate space. (Note, it's a compile time error to add a Vector3<FLU> to a Vector3<RUF>.)
 

--- a/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
+++ b/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
@@ -58,8 +58,6 @@ Add badges to main README
 
 ### Changed
 
-Update the transformation of coordinate spaces using Unity's coordinate as right, up, forward (RUF) and south, up, east (SUE).
-
 ### Deprecated
 
 ### Removed

--- a/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
+++ b/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
@@ -21,9 +21,9 @@ Upgrade the TestRosTcpConnector project to use Unity LTS version 2020.3.11f1
   - Added the CameraInfoGenerator that takes a Unity Camera and a provided HeaderMsg, generate a corresponding CameraInfoMsg, see:
     [CameraInfo Generator](https://github.com/Unity-Technologies/ROS-TCP-Connector/issues/133)
   - Added API to create TransformMsg using local frame of a transform in Unity
-
-- Added an optional pooling system for ros publishers
-- Implemented a queueing and latching system to mimic the ROS implementation in Unity
+  - Added an optional pooling system for ros publishers
+  - Implemented a queueing and latching system to mimic the ROS implementation in Unity
+  - Added geographical world coordinate transformation by a Compass component
 
 ### Changed
 - Publishing a message to an unregistered topic will show an error.

--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/Compass.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/Compass.cs
@@ -1,0 +1,237 @@
+using System;
+using UnityEngine;
+
+namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
+{
+    public enum CardinalDirection
+    {
+        North = 0,
+        East = 1,
+        South = 2,
+        West = 3,
+    }
+
+    public enum GeographicCoordinate
+    {
+        ENU,
+        NED,
+    }
+
+    public class Compass : MonoBehaviour
+    {
+        [SerializeField]
+        CardinalDirection m_UnityZAxisDirection;
+        public CardinalDirection UnityZAxisDirection
+        {
+            get => m_UnityZAxisDirection;
+            set => m_UnityZAxisDirection = value;
+        }
+
+        [SerializeField]
+        GeographicCoordinate m_Coordinate;
+        public GeographicCoordinate Coordinate
+        {
+            get => m_Coordinate;
+            set => m_Coordinate = value;
+        }
+
+        BaseCompass compass;
+
+        public Vector3 FromUnity(Vector3 v) => compass.FromUnity(v);
+        public Quaternion FromUnity(Quaternion q) => compass.FromUnity(q);
+        public Vector3 ToUnity(Vector3 v) => compass.ToUnity(v);
+        public Quaternion ToUnity(Quaternion q) => compass.ToUnity(q);
+
+        void OnValidate()
+        {
+            Initialize();
+        }
+
+        void Start()
+        {
+            if (compass == null)
+            {
+                Initialize();
+            }
+        }
+
+        void Initialize()
+        {
+            switch (Coordinate)
+            {
+                case GeographicCoordinate.ENU:
+                    compass = new EnuCompass(m_UnityZAxisDirection);
+                    break;
+                case GeographicCoordinate.NED:
+                    compass = new NedCompass(m_UnityZAxisDirection);
+                    break;
+            }
+        }
+    }
+
+    abstract class BaseCompass
+    {
+        public CardinalDirection m_UnityZAxisDirection;
+
+        public abstract Vector3 FromUnity(Vector3 v);       // convert this vector from the Unity coordinate space into geo coordinate
+        public abstract Quaternion FromUnity(Quaternion q); // convert this quaternion from the Unity coordinate space into geo coordinate
+        public abstract Vector3 ToUnity(Vector3 v);         // convert this vector from the geo coordinate space into Unity coordinate
+        public abstract Quaternion ToUnity(Quaternion q);   // convert this quaternion from the geo coordinate space into Unity coordinate
+    }
+
+    class EnuCompass : BaseCompass
+    {
+        public EnuCompass(CardinalDirection zDirection)
+        {
+            m_UnityZAxisDirection = zDirection;
+        }
+
+        public override Vector3 FromUnity(Vector3 v)
+        {
+            switch (m_UnityZAxisDirection)
+            {
+                case CardinalDirection.North:
+                    return new Vector3(v.x, v.z, v.y);
+                case CardinalDirection.East:
+                    return new Vector3(v.z, -v.x, v.y);
+                case CardinalDirection.South:
+                    return new Vector3(-v.x, -v.z, v.y);
+                case CardinalDirection.West:
+                    return new Vector3(-v.z, v.x, v.y);
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        public override Quaternion FromUnity(Quaternion q)
+        {
+            var r = q * Quaternion.Euler(0, 90 * ((int)m_UnityZAxisDirection - 1), 0);
+            switch (m_UnityZAxisDirection)
+            {
+                case CardinalDirection.North:
+                    return new Quaternion(r.x, r.z, r.y, -r.w);
+                case CardinalDirection.East:
+                    return new Quaternion(r.z, -r.x, r.y, -r.w);
+                case CardinalDirection.South:
+                    return new Quaternion(-r.x, -r.z, r.y, -r.w);
+                case CardinalDirection.West:
+                    return new Quaternion(-r.z, r.x, r.y, -r.w);
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        public override Vector3 ToUnity(Vector3 v)
+        {
+            switch (m_UnityZAxisDirection)
+            {
+                case CardinalDirection.North:
+                    return new Vector3(v.x, v.z, v.y);
+                case CardinalDirection.East:
+                    return new Vector3(-v.y, v.z, v.x);
+                case CardinalDirection.South:
+                    return new Vector3(-v.x, v.z, -v.y);
+                case CardinalDirection.West:
+                    return new Vector3(v.y, v.z, -v.x);
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        public override Quaternion ToUnity(Quaternion q)
+        {
+            var inverseRotationOffset = Quaternion.Euler(0, -90 * ((int)m_UnityZAxisDirection - 1), 0);
+            switch (m_UnityZAxisDirection)
+            {
+                case CardinalDirection.North:
+                    return new Quaternion(q.x, q.z, q.y, -q.w) * inverseRotationOffset;
+                case CardinalDirection.East:
+                    return new Quaternion(-q.y, q.z, q.x, -q.w) * inverseRotationOffset;
+                case CardinalDirection.South:
+                    return new Quaternion(-q.x, q.z, -q.y, -q.w) * inverseRotationOffset;
+                case CardinalDirection.West:
+                    return new Quaternion(q.y, q.z, -q.x, -q.w) * inverseRotationOffset;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+    }
+
+    class NedCompass : BaseCompass
+    {
+        public NedCompass(CardinalDirection zDirection)
+        {
+            m_UnityZAxisDirection = zDirection;
+        }
+
+        public override Vector3 FromUnity(Vector3 v)
+        {
+            switch (m_UnityZAxisDirection)
+            {
+                case CardinalDirection.North:
+                    return new Vector3(v.z, v.x, -v.y);
+                case CardinalDirection.East:
+                    return new Vector3(-v.x, v.z, -v.y);
+                case CardinalDirection.South:
+                    return new Vector3(-v.z, -v.x, -v.y);
+                case CardinalDirection.West:
+                    return new Vector3(v.x, -v.z, -v.y);
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        public override Quaternion FromUnity(Quaternion q)
+        {
+            var r = q * Quaternion.Euler(0, 90 * (int)m_UnityZAxisDirection, 0);
+            switch (m_UnityZAxisDirection)
+            {
+                case CardinalDirection.North:
+                    return new Quaternion(r.z, r.x, -r.y, -r.w);
+                case CardinalDirection.East:
+                    return new Quaternion(-r.x, r.z, -r.y, -r.w);
+                case CardinalDirection.South:
+                    return new Quaternion(-r.z, -r.x, -r.y, -r.w);
+                case CardinalDirection.West:
+                    return new Quaternion(r.x, -r.z, -r.y, -r.w);
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        public override Vector3 ToUnity(Vector3 v)
+        {
+            switch (m_UnityZAxisDirection)
+            {
+                case CardinalDirection.North:
+                    return new Vector3(v.y, -v.z, v.x);
+                case CardinalDirection.East:
+                    return new Vector3(-v.x, -v.z, v.y);
+                case CardinalDirection.South:
+                    return new Vector3(-v.y, -v.z, -v.x);
+                case CardinalDirection.West:
+                    return new Vector3(v.x, -v.z, -v.y);
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        public override Quaternion ToUnity(Quaternion q)
+        {
+            var inverseRotationOffset = Quaternion.Euler(0, -90 * (int)m_UnityZAxisDirection, 0);
+            switch (m_UnityZAxisDirection)
+            {
+                case CardinalDirection.North:
+                    return new Quaternion(q.y, -q.z, q.x, -q.w) * inverseRotationOffset;
+                case CardinalDirection.East:
+                    return new Quaternion(-q.x, -q.z, q.y, -q.w) * inverseRotationOffset;
+                case CardinalDirection.South:
+                    return new Quaternion(-q.y, -q.z, -q.x, -q.w) * inverseRotationOffset;
+                case CardinalDirection.West:
+                    return new Quaternion(q.x, -q.z, -q.y, -q.w) * inverseRotationOffset;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/Compass.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/Compass.cs
@@ -71,7 +71,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
 
     abstract class BaseCompass
     {
-        public CardinalDirection m_UnityZAxisDirection;
+        protected CardinalDirection m_UnityZAxisDirection;
 
         public abstract Vector3 FromUnity(Vector3 v);       // convert this vector from the Unity coordinate space into geo coordinate
         public abstract Quaternion FromUnity(Quaternion q); // convert this quaternion from the Unity coordinate space into geo coordinate

--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/Compass.cs.meta
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/Compass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ad8cf01110e54df290b36a418e91285
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
@@ -20,14 +20,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
     {
     }
 
-    /// <summary>
-    /// RUF is the Unity coordinate space, so no conversion needed
-    /// <list type="bullet">
-    ///     <item><term>X axis: </term><description>Right and South</description></item>
-    ///     <item><term>Y axis: </term><description>Up</description></item>
-    ///     <item><term>Z axis: </term><description>Forward and East</description></item>
-    /// </list>
-    /// </summary>
+    //RUF is the Unity coordinate space, so no conversion needed
     public class RUF : ICoordinateSpace
     {
         public Vector3 ConvertFromRUF(Vector3 v) => v;
@@ -36,14 +29,6 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         public Quaternion ConvertToRUF(Quaternion q) => q;
     }
 
-    /// <summary>
-    /// ROS standard forward, left, up (FLU) coordinate (REP-103)
-    /// <list type="bullet">
-    ///     <item><term>X axis: </term><description>Forward and East</description></item>
-    ///     <item><term>Y axis: </term><description>Left and North</description></item>
-    ///     <item><term>Z axis: </term><description>Up</description></item>
-    /// </list>
-    /// </summary>
     public class FLU : ICoordinateSpace
     {
         public Vector3 ConvertFromRUF(Vector3 v) => new Vector3(v.z, -v.x, v.y);
@@ -52,31 +37,21 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(-q.y, q.z, q.x, -q.w);
     }
 
-    /// <summary>
-    /// Local north, east, down (NED) coordinates for outdoor systems, such as airplane and submarine (REP-103)
-    /// <list type="bullet">
-    ///     <item><term>X axis: </term><description>North</description></item>
-    ///     <item><term>Y axis: </term><description>East</description></item>
-    ///     <item><term>Z axis: </term><description>Down</description></item>
-    /// </list>
-    /// </summary>
     public class NED : ICoordinateSpace
     {
-        public Vector3 ConvertFromRUF(Vector3 v) => new Vector3(-v.x, v.z, -v.y);
-        public Vector3 ConvertToRUF(Vector3 v) => new Vector3(-v.x, -v.z, v.y);
-        public Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(-q.x, q.z, -q.y, -q.w);
-        public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(-q.x, -q.z, q.y, -q.w);
+        public Vector3 ConvertFromRUF(Vector3 v) => new Vector3(v.z, v.x, -v.y);
+        public Vector3 ConvertToRUF(Vector3 v) => new Vector3(v.y, -v.z, v.x);
+        public Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(q.z, q.x, -q.y, -q.w);
+        public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(q.y, -q.z, q.x, -q.w);
     }
 
-    /// <summary>
-    /// Local east, north, up (ENU) coordinates for short-range Cartesian representations of geographic locations (REP-103)
-    /// <list type="bullet">
-    ///     <item><term>X axis: </term><description>East</description></item>
-    ///     <item><term>Y axis: </term><description>North</description></item>
-    ///     <item><term>Z axis: </term><description>Up</description></item>
-    /// </list>
-    /// </summary>
-    public class ENU : FLU { }
+    public class ENU : ICoordinateSpace
+    {
+        public Vector3 ConvertFromRUF(Vector3 v) => new Vector3(v.x, v.z, v.y);
+        public Vector3 ConvertToRUF(Vector3 v) => new Vector3(v.x, v.z, v.y);
+        public Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(q.x, q.z, q.y, -q.w);
+        public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(q.x, q.z, q.y, -q.w);
+    }
 
     public enum CoordinateSpaceSelection
     {


### PR DESCRIPTION
## Proposed change(s)

- [x] Revert the commit to previous coordinate convention that Unity RUF = East (x), Up (y), North (z)
- [x] Add world coordinate transformation for ENU and NED.

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [ ] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments