### PR TITLE
Revert "Update unity-ros coordinate transformation (#174)"

### DIFF
--- a/ROSGeometry.md
+++ b/ROSGeometry.md
@@ -43,7 +43,7 @@ Unity's standard Transform class also has a `To<C>()` extension method that retu
 
 # Internal details
 
-Some more detail about what's going on here: The core of the ROSGeometry package is the two generic structs, `Vector3<C>` and `Quaternion<C>`. The type parameter C here indicates the coordinate frame you're working in - either FLU, or RUF, or perhaps one of the more exotic frames such as NED (north, east, down) or ENU (east, north, up), used in aviation. In conversions between RUF and geographical coordinate systems, such as NED and ENU, the east direction is equivalent to the z-axis (forward) in RUF.
+Some more detail about what's going on here: The core of the ROSGeometry package is the two generic structs, `Vector3<C>` and `Quaternion<C>`. The type parameter C here indicates the coordinate frame you're working in - either FLU, or RUF, or perhaps one of the more exotic frames such as NED (north, east, down) or ENU (east, north, up), used in aviation.
 
 These are fully-fledged Vector3 and Quaternion classes, so if you want, you can work with them directly to perform geometric operations in an arbitrary coordinate space. (Note, it's a compile time error to add a Vector3<FLU> to a Vector3<RUF>.)
 

--- a/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
+++ b/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
@@ -58,8 +58,6 @@ Add badges to main README
 
 ### Changed
 
-Update the transformation of coordinate spaces using Unity's coordinate as right, up, forward (RUF) and south, up, east (SUE).
-
 ### Deprecated
 
 ### Removed

--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
@@ -20,14 +20,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
     {
     }
 
-    /// <summary>
-    /// RUF is the Unity coordinate space, so no conversion needed
-    /// <list type="bullet">
-    ///     <item><term>X axis: </term><description>Right and South</description></item>
-    ///     <item><term>Y axis: </term><description>Up</description></item>
-    ///     <item><term>Z axis: </term><description>Forward and East</description></item>
-    /// </list>
-    /// </summary>
+    //RUF is the Unity coordinate space, so no conversion needed
     public class RUF : ICoordinateSpace
     {
         public Vector3 ConvertFromRUF(Vector3 v) => v;
@@ -36,14 +29,6 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         public Quaternion ConvertToRUF(Quaternion q) => q;
     }
 
-    /// <summary>
-    /// ROS standard forward, left, up (FLU) coordinate (REP-103)
-    /// <list type="bullet">
-    ///     <item><term>X axis: </term><description>Forward and East</description></item>
-    ///     <item><term>Y axis: </term><description>Left and North</description></item>
-    ///     <item><term>Z axis: </term><description>Up</description></item>
-    /// </list>
-    /// </summary>
     public class FLU : ICoordinateSpace
     {
         public Vector3 ConvertFromRUF(Vector3 v) => new Vector3(v.z, -v.x, v.y);
@@ -52,31 +37,21 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(-q.y, q.z, q.x, -q.w);
     }
 
-    /// <summary>
-    /// Local north, east, down (NED) coordinates for outdoor systems, such as airplane and submarine (REP-103)
-    /// <list type="bullet">
-    ///     <item><term>X axis: </term><description>North</description></item>
-    ///     <item><term>Y axis: </term><description>East</description></item>
-    ///     <item><term>Z axis: </term><description>Down</description></item>
-    /// </list>
-    /// </summary>
     public class NED : ICoordinateSpace
     {
-        public Vector3 ConvertFromRUF(Vector3 v) => new Vector3(-v.x, v.z, -v.y);
-        public Vector3 ConvertToRUF(Vector3 v) => new Vector3(-v.x, -v.z, v.y);
-        public Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(-q.x, q.z, -q.y, -q.w);
-        public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(-q.x, -q.z, q.y, -q.w);
+        public Vector3 ConvertFromRUF(Vector3 v) => new Vector3(v.z, v.x, -v.y);
+        public Vector3 ConvertToRUF(Vector3 v) => new Vector3(v.y, -v.z, v.x);
+        public Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(q.z, q.x, -q.y, -q.w);
+        public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(q.y, -q.z, q.x, -q.w);
     }
 
-    /// <summary>
-    /// Local east, north, up (ENU) coordinates for short-range Cartesian representations of geographic locations (REP-103)
-    /// <list type="bullet">
-    ///     <item><term>X axis: </term><description>East</description></item>
-    ///     <item><term>Y axis: </term><description>North</description></item>
-    ///     <item><term>Z axis: </term><description>Up</description></item>
-    /// </list>
-    /// </summary>
-    public class ENU : FLU { }
+    public class ENU : ICoordinateSpace
+    {
+        public Vector3 ConvertFromRUF(Vector3 v) => new Vector3(v.x, v.z, v.y);
+        public Vector3 ConvertToRUF(Vector3 v) => new Vector3(v.x, v.z, v.y);
+        public Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(q.x, q.z, q.y, -q.w);
+        public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(q.x, q.z, q.y, -q.w);
+    }
 
     public enum CoordinateSpaceSelection
     {


### PR DESCRIPTION
Reverts commit c26c4cf15c05bd051d4955c3bc5e49f8633336f8 until the redesign is ready
(https://github.com/Unity-Technologies/ROS-TCP-Connector/pull/179)