### PR TITLE
Fixing a small bug in the RosTopicState.cs where MessageSender would always be null

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/RosTopicState.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/RosTopicState.cs
@@ -20,7 +20,7 @@ namespace Unity.Robotics.ROSTCPConnector
         public string RosMessageName => m_RosMessageName;
 
         TopicMessageSender m_MessageSender;
-        public TopicMessageSender MessageSender;
+        public TopicMessageSender MessageSender => m_MessageSender;
         public bool IsPublisher { get; private set; }
         public bool IsPublisherLatched { get; private set; }
         public bool SentPublisherRegistration { get; private set; }


### PR DESCRIPTION
Fixing a small bug in the RosTopicState.cs where MessageSender would always be null

## Proposed change(s)

Describe the changes made in this PR.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments