### PR TITLE
AIRO-1465 Exposing Connection Thread Data

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -90,6 +90,9 @@ namespace Unity.Robotics.ROSTCPConnector
         ConcurrentQueue<Tuple<string, byte[]>> m_IncomingMessages = new ConcurrentQueue<Tuple<string, byte[]>>();
 
         private ConnectionThreadData connectionThreadData = null;
+
+        public ConnectionThreadData CurrentConnectionThreadData => connectionThreadData;
+
         public bool HasConnectionThread => connectionThreadData != null;
 
         public bool HasConnectionError => connectionThreadData != null

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -91,8 +91,6 @@ namespace Unity.Robotics.ROSTCPConnector
 
         private ConnectionThreadData connectionThreadData = null;
 
-        public ConnectionThreadData CurrentConnectionThreadData => connectionThreadData;
-
         public bool HasConnectionThread => connectionThreadData != null;
 
         public bool HasConnectionError => connectionThreadData != null
@@ -103,6 +101,19 @@ namespace Unity.Robotics.ROSTCPConnector
             ? connectionThreadData.ConnectionState
             : ConnectionThreadState.NotConnected;
 
+        public int ConnectionAttemptCount => connectionThreadData != null
+            ? connectionThreadData.ConnectionAttemptCount
+            : 0;
+
+        //The ROS IP that that Connection Thread is actively using, may be different from RosIPAddress
+        public string ActiveRosIp => connectionThreadData != null
+            ? connectionThreadData.RosIPAddress
+            : RosIPAddress;
+
+        //The ROS port that that Connection Thread is actively using, may be different from RosPort
+        public int ActiveRosPort => connectionThreadData != null
+            ? connectionThreadData.RosPort
+            : RosPort;
 
         // only the main thread can access Time.*, so make a copy here
         public static float s_RealTimeSinceStartup = 0.0f;
@@ -736,7 +747,7 @@ namespace Unity.Robotics.ROSTCPConnector
             Connected
         }
 
-        public class ConnectionThreadData
+        private class ConnectionThreadData
         {
             public string RosIPAddress { get; }
             public int RosPort { get; }

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -803,7 +803,7 @@ namespace Unity.Robotics.ROSTCPConnector
                 try
                 {
                     connectionInfo.ConnectionState = ConnectionThreadState.AttemptingToConnect;
-                    connectionInfo.ConnectionAttemptCount ++;
+                    connectionInfo.ConnectionAttemptCount++;
 
                     client = new TcpClient();
                     client.Connect(connectionInfo.RosIPAddress, connectionInfo.RosPort);


### PR DESCRIPTION
This change is designed to expose some of the parameters around the ROSConnection.cs so that external classes could view / modify this data. My particular use case was to create a custom UI to handle the connection during play-mode without having to use the DrawHeaderGUI and GUILayout.

It doesn't actually change the functionality of the ROSConnection.cs

Provide any relevant links here.

### Types of change(s)

- [ ] Bug fix
- [X] New feature
- [X] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment.

### Test Configuration:
- Unity Version: [e.g. Unity 2021.2.0b13]
- Unity machine OS + version: [e.g. Ubuntu 18.04]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Melodic]

## Checklist
- [X] Ensured this PR is up-to-date with the `dev` branch
- [X] Created this PR to target the `dev` branch
- [X] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments