### PR TITLE
AIRO-1464 Add a try catch so that bad logic from one received message doesn't c…

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -589,7 +589,19 @@ namespace Unity.Robotics.ROSTCPConnector
                     // if this is null, we have received a message on a topic we've never heard of...!?
                     // all we can do is ignore it, we don't even know what type it is
                     if (topicInfo != null)
-                        topicInfo.OnMessageReceived(contents);
+                    {
+                        try
+                        {
+                            //Add a try catch so that bad logic from one received message doesn't
+                            //cause the Update method to exit without processing other received messages.
+                            topicInfo.OnMessageReceived(contents);
+                        }
+                        catch (Exception e)
+                        {
+                            Debug.LogException(e);
+                        }
+
+                    }
                 }
             }
         }


### PR DESCRIPTION
Copied from PR https://github.com/Unity-Technologies/ROS-TCP-Connector/pull/227

So in an ideal scenario, `topicInfo.OnMessageReceived(contents);` always works fine, but malformed messages or bad code means that sometimes that's not always the case. The idea behind this change is that even if `topicInfo.OnMessageReceived(contents);` does throw an exception, it will just move on to the next received message in the queue. Without this the Update method of the ROSConnection will exit this frame and any other waiting messages will be forced to wait for the next frame. If you have some bad actor that throws an exception every frame, you could have an unbounded queue size and messages will never get received.

Provide any relevant links here.

### Types of change(s)

- [X] Bug ~fix~/workaround
- [X] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment.

### Test Configuration:
- Unity Version: [e.g. Unity 2021.2.0b13]
- Unity machine OS + version: [e.g. Ubuntu 18.04]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Melodic]

## Checklist
- [X] Ensured this PR is up-to-date with the `dev` branch
- [X] Created this PR to target the `dev` branch
- [X] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments