### PR TITLE
Adding angular velocity conversions

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
@@ -11,6 +11,9 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
 
         Quaternion ConvertFromRUF(Quaternion q); // convert this quaternion from the Unity coordinate space into mine
         Quaternion ConvertToRUF(Quaternion q); // convert from my coordinate space into the Unity coordinate space
+
+        Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity); // convert this angular velocity from the Unity coordinate space into mine
+        Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity); // convert from my coordinate space into the Unity coordinate space
     }
 
     [Obsolete("CoordinateSpace has been renamed to ICoordinateSpace")]
@@ -25,6 +28,9 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         public Vector3 ConvertToRUF(Vector3 v) => v;
         public Quaternion ConvertFromRUF(Quaternion q) => q;
         public Quaternion ConvertToRUF(Quaternion q) => q;
+        public Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) => angularVelocity;
+
+        public Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) => angularVelocity;
     }
 
     public class FLU : ICoordinateSpace
@@ -33,6 +39,10 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         public Vector3 ConvertToRUF(Vector3 v) => new Vector3(-v.y, v.z, v.x);
         public Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(q.z, -q.x, q.y, -q.w);
         public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(-q.y, q.z, q.x, -q.w);
+        public Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) =>
+            new Vector3(-angularVelocity.z, -angularVelocity.x, -angularVelocity.y);
+        public Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) =>
+            new Vector3(-angularVelocity.y, -angularVelocity.z, -angularVelocity.x);
     }
 
     public class ENULocal : FLU { }
@@ -43,6 +53,10 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         public Vector3 ConvertToRUF(Vector3 v) => new Vector3(v.y, -v.z, v.x);
         public Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(q.z, q.x, -q.y, -q.w);
         public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(q.y, -q.z, q.x, -q.w);
+        public Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) =>
+            new Vector3(-angularVelocity.z, -angularVelocity.x, angularVelocity.y);
+        public Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) =>
+            new Vector3(-angularVelocity.y, angularVelocity.z, -angularVelocity.x);
     }
 
     public class NEDLocal : FRD { }
@@ -121,6 +135,11 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
                     throw new NotSupportedException();
             }
         }
+        //Note: Angular Velocity is the same as FRD / NEDLocal
+        public Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) =>
+            new Vector3(-angularVelocity.z, -angularVelocity.x, angularVelocity.y);
+        public Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) =>
+            new Vector3(-angularVelocity.y, angularVelocity.z, -angularVelocity.x);
     }
 
     public class ENU : ICoordinateSpace
@@ -197,6 +216,11 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
                     throw new NotSupportedException();
             }
         }
+        //Note: Angular Velocity is the same as FLU / ENULocal
+        public Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) =>
+            new Vector3(-angularVelocity.z, -angularVelocity.x, -angularVelocity.y);
+        public Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) =>
+            new Vector3(-angularVelocity.y, -angularVelocity.z, -angularVelocity.x);
     }
 
     public enum CoordinateSpaceSelection

--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
@@ -28,8 +28,8 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         public Vector3 ConvertToRUF(Vector3 v) => v;
         public Quaternion ConvertFromRUF(Quaternion q) => q;
         public Quaternion ConvertToRUF(Quaternion q) => q;
+        //No angular velocity conversion required.
         public Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) => angularVelocity;
-
         public Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) => angularVelocity;
     }
 
@@ -39,10 +39,8 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         public Vector3 ConvertToRUF(Vector3 v) => new Vector3(-v.y, v.z, v.x);
         public Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(q.z, -q.x, q.y, -q.w);
         public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(-q.y, q.z, q.x, -q.w);
-        public Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) =>
-            new Vector3(-angularVelocity.z, -angularVelocity.x, -angularVelocity.y);
-        public Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) =>
-            new Vector3(-angularVelocity.y, -angularVelocity.z, -angularVelocity.x);
+        public Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) => -ConvertFromRUF(angularVelocity);
+        public Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) => -ConvertToRUF(angularVelocity);
     }
 
     public class ENULocal : FLU { }
@@ -53,10 +51,8 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         public Vector3 ConvertToRUF(Vector3 v) => new Vector3(v.y, -v.z, v.x);
         public Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(q.z, q.x, -q.y, -q.w);
         public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(q.y, -q.z, q.x, -q.w);
-        public Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) =>
-            new Vector3(-angularVelocity.z, -angularVelocity.x, angularVelocity.y);
-        public Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) =>
-            new Vector3(-angularVelocity.y, angularVelocity.z, -angularVelocity.x);
+        public Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) => -ConvertFromRUF(angularVelocity);
+        public Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) => -ConvertToRUF(angularVelocity);
     }
 
     public class NEDLocal : FRD { }
@@ -137,9 +133,9 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         }
         //Note: Angular Velocity is the same as FRD / NEDLocal
         public Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) =>
-            new Vector3(-angularVelocity.z, -angularVelocity.x, angularVelocity.y);
+            (new FRD()).ConvertAngularVelocityFromRUF(angularVelocity);
         public Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) =>
-            new Vector3(-angularVelocity.y, angularVelocity.z, -angularVelocity.x);
+            (new FRD()).ConvertAngularVelocityToRUF(angularVelocity);
     }
 
     public class ENU : ICoordinateSpace
@@ -218,9 +214,9 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         }
         //Note: Angular Velocity is the same as FLU / ENULocal
         public Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) =>
-            new Vector3(-angularVelocity.z, -angularVelocity.x, -angularVelocity.y);
+            (new FLU()).ConvertAngularVelocityFromRUF(angularVelocity);
         public Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) =>
-            new Vector3(-angularVelocity.y, -angularVelocity.z, -angularVelocity.x);
+            (new FLU()).ConvertAngularVelocityToRUF(angularVelocity);
     }
 
     public enum CoordinateSpaceSelection


### PR DESCRIPTION
## Proposed change(s)

Although it doesn't come up often, for sensors such as the IMU / AHRS, include angular velocity. To convert angular velocity (typically from a Rigidbody / Articulation body) from Unity coordinates to FLU / RFD requires a different conversion.

So I've added angular velocity conversions ConvertAngularVelocityFromRUF and ConvertAngularVelocityToRUF to ICoordinateSpace that are handled differently than positions and rotations.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [ ] Bug fix
- [X] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment.

### Test Configuration:
- Unity Version: [e.g. Unity 2021.2.2f1]
- Unity machine OS + version: [e.g. Ubuntu 18.04]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Melodic]

## Checklist
- [X] Ensured this PR is up-to-date with the `dev` branch
- [X] Created this PR to target the `dev` branch
- [X] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments