### PR TITLE
AIRO-1590 Angular velocity conversions

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/CoordinateSpaces.cs
@@ -11,6 +11,9 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
 
         Quaternion ConvertFromRUF(Quaternion q); // convert this quaternion from the Unity coordinate space into mine
         Quaternion ConvertToRUF(Quaternion q); // convert from my coordinate space into the Unity coordinate space
+
+        Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity); // convert this angular velocity from the Unity coordinate space into mine
+        Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity); // convert from my coordinate space into the Unity coordinate space
     }
 
     [Obsolete("CoordinateSpace has been renamed to ICoordinateSpace")]
@@ -21,35 +24,55 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
     //RUF is the Unity coordinate space, so no conversion needed
     public class RUF : ICoordinateSpace
     {
-        public Vector3 ConvertFromRUF(Vector3 v) => v;
-        public Vector3 ConvertToRUF(Vector3 v) => v;
-        public Quaternion ConvertFromRUF(Quaternion q) => q;
-        public Quaternion ConvertToRUF(Quaternion q) => q;
+        Vector3 ICoordinateSpace.ConvertFromRUF(Vector3 v) => v;
+        Vector3 ICoordinateSpace.ConvertToRUF(Vector3 v) => v;
+        Quaternion ICoordinateSpace.ConvertFromRUF(Quaternion q) => q;
+        Quaternion ICoordinateSpace.ConvertToRUF(Quaternion q) => q;
+        Vector3 ICoordinateSpace.ConvertAngularVelocityFromRUF(Vector3 angularVelocity) => angularVelocity;
+        Vector3 ICoordinateSpace.ConvertAngularVelocityToRUF(Vector3 angularVelocity) => angularVelocity;
     }
 
     public class FLU : ICoordinateSpace
     {
-        public Vector3 ConvertFromRUF(Vector3 v) => new Vector3(v.z, -v.x, v.y);
-        public Vector3 ConvertToRUF(Vector3 v) => new Vector3(-v.y, v.z, v.x);
-        public Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(q.z, -q.x, q.y, -q.w);
-        public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(-q.y, q.z, q.x, -q.w);
+        public static Vector3 ConvertFromRUF(Vector3 v) => new Vector3(v.z, -v.x, v.y);
+        public static Vector3 ConvertToRUF(Vector3 v) => new Vector3(-v.y, v.z, v.x);
+        public static Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(q.z, -q.x, q.y, -q.w);
+        public static Quaternion ConvertToRUF(Quaternion q) => new Quaternion(-q.y, q.z, q.x, -q.w);
+        public static Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) => -FLU.ConvertFromRUF(angularVelocity);
+        public static Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) => -FLU.ConvertToRUF(angularVelocity);
+
+        Vector3 ICoordinateSpace.ConvertFromRUF(Vector3 v) => FLU.ConvertFromRUF(v);
+        Vector3 ICoordinateSpace.ConvertToRUF(Vector3 v) => FLU.ConvertToRUF(v);
+        Quaternion ICoordinateSpace.ConvertFromRUF(Quaternion q) => FLU.ConvertFromRUF(q);
+        Quaternion ICoordinateSpace.ConvertToRUF(Quaternion q) => FLU.ConvertToRUF(q);
+        Vector3 ICoordinateSpace.ConvertAngularVelocityFromRUF(Vector3 angularVelocity) => FLU.ConvertAngularVelocityFromRUF(angularVelocity);
+        Vector3 ICoordinateSpace.ConvertAngularVelocityToRUF(Vector3 angularVelocity) => FLU.ConvertAngularVelocityToRUF(angularVelocity);
     }
 
     public class ENULocal : FLU { }
 
     public class FRD : ICoordinateSpace
     {
-        public Vector3 ConvertFromRUF(Vector3 v) => new Vector3(v.z, v.x, -v.y);
-        public Vector3 ConvertToRUF(Vector3 v) => new Vector3(v.y, -v.z, v.x);
-        public Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(q.z, q.x, -q.y, -q.w);
-        public Quaternion ConvertToRUF(Quaternion q) => new Quaternion(q.y, -q.z, q.x, -q.w);
+        public static Vector3 ConvertFromRUF(Vector3 v) => new Vector3(v.z, v.x, -v.y);
+        public static Vector3 ConvertToRUF(Vector3 v) => new Vector3(v.y, -v.z, v.x);
+        public static Quaternion ConvertFromRUF(Quaternion q) => new Quaternion(q.z, q.x, -q.y, -q.w);
+        public static Quaternion ConvertToRUF(Quaternion q) => new Quaternion(q.y, -q.z, q.x, -q.w);
+        public static Vector3 ConvertAngularVelocityFromRUF(Vector3 angularVelocity) => -ConvertFromRUF(angularVelocity);
+        public static Vector3 ConvertAngularVelocityToRUF(Vector3 angularVelocity) => -ConvertToRUF(angularVelocity);
+
+        Vector3 ICoordinateSpace.ConvertFromRUF(Vector3 v) => FRD.ConvertFromRUF(v);
+        Vector3 ICoordinateSpace.ConvertToRUF(Vector3 v) => FRD.ConvertToRUF(v);
+        Quaternion ICoordinateSpace.ConvertFromRUF(Quaternion q) => FRD.ConvertFromRUF(q);
+        Quaternion ICoordinateSpace.ConvertToRUF(Quaternion q) => FRD.ConvertToRUF(q);
+        Vector3 ICoordinateSpace.ConvertAngularVelocityFromRUF(Vector3 angularVelocity) => FRD.ConvertAngularVelocityFromRUF(angularVelocity);
+        Vector3 ICoordinateSpace.ConvertAngularVelocityToRUF(Vector3 angularVelocity) => FRD.ConvertAngularVelocityToRUF(angularVelocity);
     }
 
     public class NEDLocal : FRD { }
 
     public class NED : ICoordinateSpace
     {
-        public Vector3 ConvertFromRUF(Vector3 v)
+        public static Vector3 ConvertFromRUF(Vector3 v)
         {
             switch (GeometryCompass.UnityZAxisDirection)
             {
@@ -66,7 +89,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
             }
         }
 
-        public Vector3 ConvertToRUF(Vector3 v)
+        public static Vector3 ConvertToRUF(Vector3 v)
         {
             switch (GeometryCompass.UnityZAxisDirection)
             {
@@ -83,7 +106,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
             }
         }
 
-        public Quaternion ConvertFromRUF(Quaternion q)
+        public static Quaternion ConvertFromRUF(Quaternion q)
         {
             switch (GeometryCompass.UnityZAxisDirection)
             {
@@ -104,7 +127,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
             return new Quaternion(q.z, q.x, -q.y, -q.w);
         }
 
-        public Quaternion ConvertToRUF(Quaternion q)
+        public static Quaternion ConvertToRUF(Quaternion q)
         {
             var r = new Quaternion(q.y, -q.z, q.x, -q.w);
             switch (GeometryCompass.UnityZAxisDirection)
@@ -121,11 +144,18 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
                     throw new NotSupportedException();
             }
         }
+        Vector3 ICoordinateSpace.ConvertFromRUF(Vector3 v) => NED.ConvertFromRUF(v);
+        Vector3 ICoordinateSpace.ConvertToRUF(Vector3 v) => NED.ConvertToRUF(v);
+        Quaternion ICoordinateSpace.ConvertFromRUF(Quaternion q) => NED.ConvertFromRUF(q);
+        Quaternion ICoordinateSpace.ConvertToRUF(Quaternion q) => NED.ConvertToRUF(q);
+        //Note: Angular Velocity is the same as FRD / NEDLocal
+        Vector3 ICoordinateSpace.ConvertAngularVelocityFromRUF(Vector3 angularVelocity) => FRD.ConvertAngularVelocityFromRUF(angularVelocity);
+        Vector3 ICoordinateSpace.ConvertAngularVelocityToRUF(Vector3 angularVelocity) => FRD.ConvertAngularVelocityToRUF(angularVelocity);
     }
 
     public class ENU : ICoordinateSpace
     {
-        public Vector3 ConvertFromRUF(Vector3 v)
+        public static Vector3 ConvertFromRUF(Vector3 v)
         {
             switch (GeometryCompass.UnityZAxisDirection)
             {
@@ -141,7 +171,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
                     throw new NotSupportedException();
             }
         }
-        public Vector3 ConvertToRUF(Vector3 v)
+        public static Vector3 ConvertToRUF(Vector3 v)
         {
             switch (GeometryCompass.UnityZAxisDirection)
             {
@@ -158,7 +188,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
             }
         }
 
-        public Quaternion ConvertFromRUF(Quaternion q)
+        public static Quaternion ConvertFromRUF(Quaternion q)
         {
             switch (GeometryCompass.UnityZAxisDirection)
             {
@@ -180,7 +210,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
             return new Quaternion(q.z, -q.x, q.y, -q.w);
         }
 
-        public Quaternion ConvertToRUF(Quaternion q)
+        public static Quaternion ConvertToRUF(Quaternion q)
         {
             q = new Quaternion(-q.y, q.z, q.x, -q.w);
             switch (GeometryCompass.UnityZAxisDirection)
@@ -197,6 +227,14 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
                     throw new NotSupportedException();
             }
         }
+
+        Vector3 ICoordinateSpace.ConvertFromRUF(Vector3 v) => ENU.ConvertFromRUF(v);
+        Vector3 ICoordinateSpace.ConvertToRUF(Vector3 v) => ENU.ConvertToRUF(v);
+        Quaternion ICoordinateSpace.ConvertFromRUF(Quaternion q) => ENU.ConvertFromRUF(q);
+        Quaternion ICoordinateSpace.ConvertToRUF(Quaternion q) => ENU.ConvertToRUF(q);
+        //Note: Angular Velocity is the same as FLU / ENULocal
+        Vector3 ICoordinateSpace.ConvertAngularVelocityFromRUF(Vector3 angularVelocity) => FLU.ConvertAngularVelocityFromRUF(angularVelocity);
+        Vector3 ICoordinateSpace.ConvertAngularVelocityToRUF(Vector3 angularVelocity) => FLU.ConvertAngularVelocityToRUF(angularVelocity);
     }
 
     public enum CoordinateSpaceSelection

--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/ROSVector3.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/ROSVector3.cs
@@ -30,6 +30,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         }
 
         public Vector3 toUnity => s_CoordinateSpace.ConvertToRUF(internalVector);
+        public Vector3 toUnityAngularVelocity => s_CoordinateSpace.ConvertAngularVelocityToRUF(internalVector);
 
         public static explicit operator Vector3<C>(Vector3 vec)
         {
@@ -44,6 +45,11 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
         public Vector3<C2> To<C2>() where C2 : ICoordinateSpace, new()
         {
             return (Vector3<C2>)(Vector3)this;
+        }
+
+        public static Vector3<C> FromUnityAngularVelocity(Vector3 angularVelocityRUF)
+        {
+            return new Vector3<C> { internalVector = s_CoordinateSpace.ConvertAngularVelocityFromRUF(angularVelocityRUF) };
         }
 
         // for internal use only - this function does not convert coordinate spaces correctly


### PR DESCRIPTION
Reimplementation of https://github.com/Unity-Technologies/ROS-TCP-Connector/pull/239

  Notable changes: All nontrivial coordinate conversion functions are now available as static methods, which the interface implementation methods forward to, so that you can just write FLU.ConvertToRUF instead of (new FLU()).ConvertToRUF.
  Added conversion functions to Vector3<C> (since that's supposed to be the main user-facing part of this system).