### PR TITLE
AIRO-1647 Adding scripted Action importer and fixing action message registration

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/ActionAutoGen.cs
+++ b/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/ActionAutoGen.cs
@@ -87,6 +87,8 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
                     className,
                     subtopic: subtopics[i]
                 );
+                // >>> TODO: Parser will add registration methods for subtypes, but should we include here?
+                //           subtypes get published to sub-topics, do we ever subscribe to them directly?
                 parser.Parse();
                 warnings.AddRange(parser.GetWarnings());
 
@@ -353,6 +355,9 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
                 writer.Write(GenerateDeserializerConstructor(wrapperName));
 
                 writer.Write(GenerateSerializationStatements(type));
+               
+                // Omit the subtype because subtype is baked into the class name
+                writer.Write(MsgAutoGenUtilities.InitializeOnLoad());
 
                 // Close class
                 writer.Write(ONE_TAB + "}\n");

--- a/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/ActionAutoGen.cs
+++ b/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/ActionAutoGen.cs
@@ -87,8 +87,6 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
                     className,
                     subtopic: subtopics[i]
                 );
-                // >>> TODO: Parser will add registration methods for subtypes, but should we include here?
-                //           subtypes get published to sub-topics, do we ever subscribe to them directly?
                 parser.Parse();
                 warnings.AddRange(parser.GetWarnings());
 
@@ -355,7 +353,7 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
                 writer.Write(GenerateDeserializerConstructor(wrapperName));
 
                 writer.Write(GenerateSerializationStatements(type));
-               
+
                 // Omit the subtype because subtype is baked into the class name
                 writer.Write(MsgAutoGenUtilities.InitializeOnLoad());
 

--- a/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/MessageParser.cs
+++ b/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/MessageParser.cs
@@ -154,7 +154,7 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
                 // Write ToString override
                 writer.Write(GenerateToString());
 
-                var subtopicParameter = 
+                var subtopicParameter =
                     subtopic == MessageSubtopic.Default ? "" : $", MessageSubtopic.{subtopic}";
 
                 writer.Write(InitializeOnLoad(subtopicParameter));

--- a/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/MessageParser.cs
+++ b/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/MessageParser.cs
@@ -154,20 +154,10 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
                 // Write ToString override
                 writer.Write(GenerateToString());
 
-                string subtopicParameter = subtopic == MessageSubtopic.Default ? "" : $", MessageSubtopic.{subtopic}";
+                var subtopicParameter = 
+                    subtopic == MessageSubtopic.Default ? "" : $", MessageSubtopic.{subtopic}";
 
-                writer.Write(
-                    "\n" +
-                    "#if UNITY_EDITOR\n" +
-                    TWO_TABS + "[UnityEditor.InitializeOnLoadMethod]\n" +
-                    "#else\n" +
-                    TWO_TABS + "[UnityEngine.RuntimeInitializeOnLoadMethod]\n" +
-                    "#endif\n" +
-                    TWO_TABS + "public static void Register()\n" +
-                    TWO_TABS + "{\n" +
-                    THREE_TABS + $"MessageRegistry.Register(k_RosMessageName, Deserialize{subtopicParameter});\n" +
-                    TWO_TABS + "}\n"
-                );
+                writer.Write(InitializeOnLoad(subtopicParameter));
 
                 // Close class
                 writer.Write(MsgAutoGenUtilities.ONE_TAB + "}\n");

--- a/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/MsgAutoGenUtilities.cs
+++ b/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/MsgAutoGenUtilities.cs
@@ -147,5 +147,19 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
             }
             return CapitalizeFirstLetter(s);
         }
+
+        public static string InitializeOnLoad(string subtopicArgument = "")
+        {
+            return "\n" +
+                "#if UNITY_EDITOR\n" +
+                TWO_TABS + "[UnityEditor.InitializeOnLoadMethod]\n" +
+                "#else\n" +
+                TWO_TABS + "[UnityEngine.RuntimeInitializeOnLoadMethod]\n" +
+                "#endif\n" +
+                TWO_TABS + "public static void Register()\n" +
+                TWO_TABS + "{\n" +
+                THREE_TABS + $"MessageRegistry.Register(k_RosMessageName, Deserialize{subtopicArgument});\n" +
+                TWO_TABS + "}\n";
+        }
     }
 }

--- a/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/ScriptedActionImporter.cs
+++ b/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/ScriptedActionImporter.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using Unity.Robotics.ROSTCPConnector.MessageGeneration;
+using UnityEditor;
+using UnityEngine;
+#if UNITY_2020_2_OR_NEWER
+using UnityEditor.AssetImporters;
+#else
+using UnityEditor.Experimental.AssetImporters;
+#endif
+
+namespace Unity.Robotics.ROSTCPConnector.Editor.MessageGeneration
+{
+    [ScriptedImporter(1, "action")]
+    public class ScriptedActionImporter : ScriptedImporter
+    {
+        public override void OnImportAsset(AssetImportContext ctx)
+        {
+            var inputPath = Path.Combine(Directory.GetCurrentDirectory(), ctx.assetPath);
+            var outputPath = MessageGenBrowserSettings.Get().outputPath;
+            ActionAutoGen.GenerateSingleAction(inputPath, MessageGenBrowserSettings.Get().outputPath);
+
+            foreach (string builtPath in ServiceAutoGen.GetServiceClassPaths(inputPath, outputPath))
+            {
+                var builtAssetPath = Path.Combine("Assets", MessageGenBrowserSettings.ToRelativePath(builtPath));
+                AssetDatabase.ImportAsset(builtAssetPath);
+                var messageClass = AssetDatabase.LoadAssetAtPath(builtAssetPath, typeof(MonoScript));
+                if (messageClass != null)
+                    ctx.AddObjectToAsset("messageClass", messageClass);
+            }
+        }
+    }
+}

--- a/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/ScriptedActionImporter.cs.meta
+++ b/com.unity.robotics.ros-tcp-connector/Editor/MessageGeneration/ScriptedActionImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a80f940ccb8ea1b4f9bd32fdc136bdce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Proposed change(s)

Part 4 of Pick and Place was publishing messages over a service topic using a standard ROS Publisher rather than our API for Services. It also seems to be broken in general due to actions not registering to the message registry. Modified project on both Unity and ROS side to use the Service API for service messages, and added some quality of life updates to the ROS node so starting it without an accompanying Niryo One param server doesn't lock up a user's terminal.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Addresses a [Robotics Hub issue](https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/333) and [this forum post](https://forum.unity.com/threads/followjointtrajectory-action-does-not-generate-register-code.1201636/).

### Types of change(s)

- [x] Bug fix

## Testing and Verification

Ran nodes up to the point where they fail to connect to a Niryo One, which I don't have on hand.

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/Unity-Robotics-Hub/blob/dev/CHANGELOG.md#unreleased)
- [x] Updated the documentation as appropriate

## Other comments
