### PR TITLE
AIRO-1685 Add log error for empty MessageRegistry

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/MessageGeneration/MessageRegistry.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/MessageGeneration/MessageRegistry.cs
@@ -45,6 +45,11 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
 
         public static string GetRosMessageName<T>() where T : Message
         {
+            if (string.IsNullOrEmpty(RegistryEntry<T>.s_RosMessageName))
+            {
+                Debug.LogError($"Can't find MessageRegistry entry for {typeof(T)}! If Register<T> is called before " +
+                               $"Start(), please specify ROS message name, or move initialization to Start().");
+            }
             return RegistryEntry<T>.s_RosMessageName;
         }
 


### PR DESCRIPTION
## Proposed change(s)

Adding a log error for not found registry entry.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

https://github.com/Unity-Technologies/ROS-TCP-Endpoint/pull/136

https://github.com/Unity-Technologies/ROS-TCP-Endpoint/pull/137

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)