### PR TITLE
AIRO-1765 Cleanup for ImageDefaultVisualizer

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/Extensions/MessageExtensions.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Extensions/MessageExtensions.cs
@@ -147,7 +147,7 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
         /// <summary>
         /// Converts a byte array from BGR to RGB.
         /// </summary>
-        static byte[] EncodingConversion(ImageMsg image, bool convertBGR = true, bool flipY = true)
+        public static byte[] EncodingConversion(ImageMsg image, bool convertBGR = true, bool flipY = true)
         {
             // Number of channels in this encoding
             int channels = image.GetNumChannels();
@@ -511,12 +511,14 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
                 case "32SC2":
                 case "32SC3":
                 case "32SC4":
+                    // TODO: Experimental.Rendering.GraphicsFormat.R32_SInt
                     throw new NotImplementedException("32 bit integer texture formats are not supported");
                 case "32FC1":
                     return TextureFormat.RFloat;
                 case "32FC2":
                     return TextureFormat.RGFloat;
                 case "32FC3":
+                    // TODO: Experimental.Rendering.GraphicsFormat.R32G32B32_SFloat
                     throw new NotImplementedException("32FC3 texture format is not supported");
                 case "32FC4":
                     return TextureFormat.RGBAFloat;

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/ImageDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/ImageDefaultVisualizer.cs
@@ -10,6 +10,8 @@ public class ImageDefaultVisualizer : BaseVisualFactory<ImageMsg>
 {
     [SerializeField]
     bool m_Debayer = true;
+    [SerializeField]
+    bool m_ShowSingleChannelAsGray = true;
 
     public override bool CanShowDrawing => false;
 
@@ -32,11 +34,16 @@ public class ImageDefaultVisualizer : BaseVisualFactory<ImageMsg>
 
         // after anyone asks for it, we cache the properly processed texture here
         Texture2D m_Texture2D;
+        bool m_Texture2DIsDirty;
+        string m_Texture2DEncoding;
         // if nobody asks for the proper texture, we generate CheapTexture2D: this is just
         // the raw bytes from the message, dumped into a texture.
         // cheap to make but will look wrong without a special shader
         Texture2D m_CheapTexture2D;
+        bool m_CheapTexture2DIsDirty;
+        string m_CheapTexture2DEncoding;
         Material m_CheapTextureMaterial;
+
         List<Action<Texture2D>> m_OnChangeCallbacks = new List<Action<Texture2D>>();
 
         public void ListenForTextureChange(Action<Texture2D> callback)
@@ -60,20 +67,26 @@ public class ImageDefaultVisualizer : BaseVisualFactory<ImageMsg>
                 return;
 
             this.message = (ImageMsg)message;
-            m_Texture2D = null;
-            m_CheapTexture2D = null;
+            m_Texture2DIsDirty = true;
+            m_CheapTexture2DIsDirty = true;
             m_Width = (int)this.message.width;
             m_Height = (int)this.message.height;
             m_Encoding = this.message.encoding;
             //m_CheapTextureMaterial.SetFloat("_gray", this.message.GetNumChannels() == 1 ? 1.0f : 0.0f);
-            m_CheapTextureMaterial.SetFloat("_convertBGR", this.message.EncodingRequiresBGRConversion() ? 1.0f : 0.0f);
 
             // if anyone wants to know about the texture, notify them
             if (m_OnChangeCallbacks.Count > 0)
-                GetTexture();
+            {
+                GetTexture(); // force m_Texture2D to update
+                foreach (Action<Texture2D> callback in m_OnChangeCallbacks)
+                    callback(m_Texture2D);
+            }
         }
 
         public ImageMsg message { get; private set; }
+
+        static int ConvertBGRPropertyID = Shader.PropertyToID("_convertBGR");
+        static int GrayPropertyID = Shader.PropertyToID("_gray");
 
         public void OnGUI()
         {
@@ -84,40 +97,71 @@ public class ImageDefaultVisualizer : BaseVisualFactory<ImageMsg>
             }
 
             message.header.GUI();
-            GUILayout.Label($"{m_Height}x{m_Width}, encoding: {m_Encoding}");
-            if (message.data.Length > 0)
+            if (message.data.Length <= 0)
             {
-                GUILayout.BeginHorizontal();
-                if (m_Encoding.StartsWith("bayer"))
-                    m_Debayer = GUILayout.Toggle(m_Debayer, "Debayer");
-                GUILayout.EndHorizontal();
+                GUILayout.Label($"{m_Height}x{m_Width}, encoding: {m_Encoding}");
+                return;
+            }
 
-                if (m_Texture2D != null || m_Debayer)
-                {
-                    // if we already generated the "real" texture, just use that
-                    GetTexture().GUITexture();
-                }
-                else
-                {
-                    if (m_CheapTexture2D == null)
-                    {
-                        m_CheapTexture2D = message.ToTexture2D(m_Debayer, convertBGR: false, flipY: false);
-                    }
-                    m_CheapTexture2D.GUITexture(m_CheapTextureMaterial);
-                }
+            bool isBayerImage = m_Encoding.StartsWith("bayer");
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label($"{m_Height}x{m_Width}, encoding: {m_Encoding}");
+            if (isBayerImage)
+                m_Debayer = GUILayout.Toggle(m_Debayer, "Debayer");
+            GUILayout.EndHorizontal();
+
+            if (m_Texture2D != null || (m_Debayer && isBayerImage))
+            {
+                // if we already generated the "real" texture, just use that
+                GetTexture().GUITexture();
+            }
+            else
+            {
+                TextureRefresh(ref m_CheapTexture2D, ref m_CheapTexture2DEncoding, ref m_CheapTexture2DIsDirty, doConversion: false);
+
+                m_CheapTextureMaterial.SetFloat(ConvertBGRPropertyID, message.EncodingRequiresBGRConversion() ? 1.0f : 0.0f);
+                bool gray = (m_Factory.m_ShowSingleChannelAsGray && message.GetNumChannels() == 1);
+                m_CheapTextureMaterial.SetFloat(GrayPropertyID, gray ? 1.0f : 0.0f);
+                m_CheapTexture2D.GUITexture(m_CheapTextureMaterial);
             }
         }
 
         public Texture2D GetTexture()
         {
-            if (m_Texture2D == null)
-            {
-                m_Texture2D = (message != null && message.data.Length > 0) ? message.ToTexture2D(m_Debayer) : null;
-
-                foreach (Action<Texture2D> callback in m_OnChangeCallbacks)
-                    callback(m_Texture2D);
-            }
+            TextureRefresh(ref m_Texture2D, ref m_Texture2DEncoding, ref m_Texture2DIsDirty, doConversion: true);
             return m_Texture2D;
+        }
+
+        void TextureRefresh(ref Texture2D texture, ref string encoding, ref bool isDirty, bool doConversion)
+        {
+            if (texture == null || encoding != message.encoding || (m_Debayer && encoding.StartsWith("bayer")))
+            {
+                // texture is incompatible, we'll have to make a new one; so destroy the old one now
+                if (texture != null)
+                    Destroy(texture);
+
+                if (doConversion)
+                    texture = message.ToTexture2D(debayer: m_Debayer);
+                else
+                    texture = message.ToTexture2D(debayer: false, convertBGR: false, flipY: false);
+
+                encoding = message.encoding;
+                isDirty = false;
+            }
+            else if (isDirty)
+            {
+                if (texture.width != message.width || texture.height != message.height)
+                {
+                    texture.Resize((int)message.width, (int)message.height);
+                }
+
+                byte[] convertedData = (doConversion) ? MessageExtensions.EncodingConversion(message, message.EncodingRequiresBGRConversion(), flipY: true) : message.data;
+
+                texture.LoadRawTextureData(convertedData);
+                texture.Apply();
+                isDirty = false;
+            }
         }
 
         public bool IsDrawingEnabled => false;


### PR DESCRIPTION
Fixes:
Destroy textures when they're no longer in use
Reuse textures where possible
Display single-channel images as greyscale instead of red