### PR TITLE
AIRO-1848 Create linear textures where appropriate

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/Extensions/MessageExtensions.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Extensions/MessageExtensions.cs
@@ -562,15 +562,16 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
         {
             Texture2D tex;
             byte[] data;
+            bool linear = QualitySettings.activeColorSpace == ColorSpace.Linear;
             if (debayer && message.IsBayerEncoded())
             {
-                tex = new Texture2D((int)message.width / 2, (int)message.height / 2, TextureFormat.RGBA32, false);
+                tex = new Texture2D((int)message.width / 2, (int)message.height / 2, TextureFormat.RGBA32, false, linear);
                 message.DebayerConvert(flipY);
                 data = message.data;
             }
             else
             {
-                tex = new Texture2D((int)message.width, (int)message.height, message.GetTextureFormat(), false);
+                tex = new Texture2D((int)message.width, (int)message.height, message.GetTextureFormat(), false, linear);
                 data = EncodingConversion(message, convertBGR, flipY);
             }
 


### PR DESCRIPTION
When a project is using linear color space, newly created textures should be in linear color space.