### PR TITLE
AIRO-1856 Added "Relative to Visualizer" tf tracking mode

### DIFF
--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/AccelStampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/AccelStampedDefaultVisualizer.cs
@@ -17,7 +17,7 @@ public class AccelStampedDefaultVisualizer : DrawingVisualizer<AccelStampedMsg>
 
     public override void Draw(Drawing3d drawing, AccelStampedMsg message, MessageMetadata meta)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         AccelDefaultVisualizer.Draw<FLU>(message.accel, drawing, SelectColor(m_Color, meta), m_Origin, m_LengthScale, m_SphereRadius, m_Thickness);
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/AccelWithCovarianceStampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/AccelWithCovarianceStampedDefaultVisualizer.cs
@@ -18,7 +18,7 @@ public class AccelWithCovarianceStampedDefaultVisualizer : DrawingVisualizer<Acc
 
     public override void Draw(Drawing3d drawing, AccelWithCovarianceStampedMsg message, MessageMetadata meta)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         AccelWithCovarianceDefaultVisualizer.Draw<FLU>(message.accel, drawing, SelectColor(m_Color, meta), m_Origin, m_LengthScale, m_SphereRadius, m_Thickness);
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/InertiaStampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/InertiaStampedDefaultVisualizer.cs
@@ -17,7 +17,7 @@ public class InertiaStampedDefaultVisualizer : DrawingVisualizer<InertiaStampedM
 
     public override void Draw(Drawing3d drawing, InertiaStampedMsg message, MessageMetadata meta)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingType, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingType, message.header, transform);
         Vector3DefaultVisualizer.Draw<FLU>(message.inertia.com, drawing, m_Origin, SelectColor(m_Color, meta), SelectLabel(m_Label, meta), m_Radius);
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/PointStampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/PointStampedDefaultVisualizer.cs
@@ -18,7 +18,7 @@ namespace Unity.Robotics.Visualizations
 
         public override void Draw(Drawing3d drawing, PointStampedMsg message, MessageMetadata meta)
         {
-            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
             PointDefaultVisualizer.Draw<FLU>(message.point, drawing, SelectColor(m_Color, meta), SelectLabel(m_Label, meta), m_Radius);
         }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/PolygonStampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/PolygonStampedDefaultVisualizer.cs
@@ -16,7 +16,7 @@ namespace Unity.Robotics.Visualizations
 
         public override void Draw(Drawing3d drawing, PolygonStampedMsg message, MessageMetadata meta)
         {
-            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
             PolygonDefaultVisualizer.Draw<FLU>(message.polygon, drawing, SelectColor(m_Color, meta), m_Thickness);
         }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/PoseArrayDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/PoseArrayDefaultVisualizer.cs
@@ -16,7 +16,7 @@ public class PoseArrayDefaultVisualizer : DrawingVisualizer<PoseArrayMsg>
 
     public override void Draw(Drawing3d drawing, PoseArrayMsg message, MessageMetadata meta)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         Draw<FLU>(message, drawing, m_Size, m_DrawUnityAxes);
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/PoseStampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/PoseStampedDefaultVisualizer.cs
@@ -16,7 +16,7 @@ public class PoseStampedDefaultVisualizer : DrawingVisualizer<PoseStampedMsg>
 
     public override void Draw(Drawing3d drawing, PoseStampedMsg message, MessageMetadata meta)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         PoseDefaultVisualizer.Draw<FLU>(message.pose, drawing, m_Size, m_DrawUnityAxes);
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/PoseWithCovarianceStampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/PoseWithCovarianceStampedDefaultVisualizer.cs
@@ -17,7 +17,7 @@ public class PoseWithCovarianceStampedDefaultVisualizer : DrawingVisualizer<Pose
 
     public override void Draw(Drawing3d drawing, PoseWithCovarianceStampedMsg message, MessageMetadata meta)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         PoseDefaultVisualizer.Draw<FLU>(message.pose.pose, drawing, m_Size, m_DrawUnityAxes);
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/QuaternionStampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/QuaternionStampedDefaultVisualizer.cs
@@ -23,7 +23,7 @@ namespace Unity.Robotics.Visualizations
 
         public override void Draw(Drawing3d drawing, QuaternionStampedMsg message, MessageMetadata meta)
         {
-            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
             QuaternionDefaultVisualizer.Draw<FLU>(message.quaternion, drawing, m_DrawAtPosition, m_Size, m_DrawUnityAxes);
             drawing.DrawLabel(SelectLabel(m_Label, meta), transform.position, SelectColor(m_Color, meta), m_Size);
         }

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/TransformStampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/TransformStampedDefaultVisualizer.cs
@@ -21,7 +21,7 @@ namespace Unity.Robotics.Visualizations
 
         public override void Draw(Drawing3d drawing, TransformStampedMsg message, MessageMetadata meta)
         {
-            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
             TransformDefaultVisualizer.Draw<FLU>(message.transform, drawing, m_Size, m_DrawUnityAxes);
             drawing.DrawLabel(SelectLabel(m_Label, meta), message.transform.translation.From<FLU>(), SelectColor(m_Color, meta), m_Size);
         }

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/TwistStampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/TwistStampedDefaultVisualizer.cs
@@ -18,7 +18,7 @@ namespace Unity.Robotics.Visualizations
 
         public override void Draw(Drawing3d drawing, TwistStampedMsg message, MessageMetadata meta)
         {
-            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
             var orig = origin == null ? Vector3.zero : origin.transform.position;
             TwistDefaultVisualizer.Draw<FLU>(message.twist, drawing, SelectColor(m_Color, meta), orig, lengthScale, sphereRadius, thickness);
         }

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/TwistWithCovarianceStampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/TwistWithCovarianceStampedDefaultVisualizer.cs
@@ -19,7 +19,7 @@ namespace Unity.Robotics.Visualizations
 
         public override void Draw(Drawing3d drawing, TwistWithCovarianceStampedMsg message, MessageMetadata meta)
         {
-            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
             var orig = origin == null ? Vector3.zero : origin.transform.position;
             TwistWithCovarianceDefaultVisualizer.Draw<FLU>(message.twist, drawing, SelectColor(m_Color, meta), orig, lengthScale, sphereRadius, thickness);
         }

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/Vector3StampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/Vector3StampedDefaultVisualizer.cs
@@ -18,7 +18,7 @@ namespace Unity.Robotics.Visualizations
 
         public override void Draw(Drawing3d drawing, Vector3StampedMsg message, MessageMetadata meta)
         {
-            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
             Vector3DefaultVisualizer.Draw<FLU>(message.vector, drawing, SelectColor(m_Color, meta), SelectLabel(m_Label, meta), m_Radius);
         }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/WrenchStampedDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Geometry/WrenchStampedDefaultVisualizer.cs
@@ -18,7 +18,7 @@ namespace Unity.Robotics.Visualizations
 
         public override void Draw(Drawing3d drawing, WrenchStampedMsg message, MessageMetadata meta)
         {
-            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+            drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
             WrenchDefaultVisualizer.Draw<FLU>(message.wrench, drawing, SelectColor(m_Color, meta), origin.transform.position, lengthScale, sphereRadius, thickness);
         }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Nav/GridCellsDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Nav/GridCellsDefaultVisualizer.cs
@@ -14,7 +14,7 @@ public class GridCellsDefaultVisualizer : DrawingVisualizer<GridCellsMsg>
     TFTrackingSettings m_TFTrackingSettings;
     public override void Draw(Drawing3d drawing, GridCellsMsg message, MessageMetadata meta)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         Draw<FLU>(message, drawing, SelectColor(m_Color, meta), m_Radius);
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Nav/OccupancyGridDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Nav/OccupancyGridDefaultVisualizer.cs
@@ -118,7 +118,7 @@ public class OccupancyGridDefaultVisualizer : BaseVisualFactory<OccupancyGridMsg
                 m_Drawing.Clear();
             }
 
-            m_Drawing.SetTFTrackingSettings(m_Settings.m_TFTrackingSettings, m_Message.header);
+            m_Drawing.SetTFTrackingSettings(m_Settings.m_TFTrackingSettings, m_Message.header, m_Settings.transform);
             // offset the mesh by half a grid square, because the message's position defines the CENTER of grid square 0,0
             Vector3 drawOrigin = origin - rotation * new Vector3(scale * 0.5f, 0, scale * 0.5f) + m_Settings.m_Offset;
             m_Drawing.DrawMesh(m_Mesh, drawOrigin, rotation,

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Nav/OdometryDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Nav/OdometryDefaultVisualizer.cs
@@ -16,7 +16,7 @@ public class OdometryDefaultVisualizer : DrawingVisualizer<OdometryMsg>
 
     public override void Draw(Drawing3d drawing, OdometryMsg message, MessageMetadata meta)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         Draw<FLU>(message, drawing, SelectColor(m_Color, meta), lengthScale, sphereRadius, thickness);
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Nav/PathDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Nav/PathDefaultVisualizer.cs
@@ -19,7 +19,7 @@ public class PathDefaultVisualizer : DrawingVisualizer<PathMsg>
 
     public override void Draw(Drawing3d drawing, PathMsg message, MessageMetadata meta)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         Draw<FLU>(message, drawing, SelectColor(m_Color, meta), m_Thickness, m_Offset);
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/ImuDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/ImuDefaultVisualizer.cs
@@ -27,7 +27,7 @@ public class ImuDefaultVisualizer : DrawingVisualizer<ImuMsg>
 
     public override void Draw(Drawing3d drawing, ImuMsg message, MessageMetadata meta)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         Draw<FLU>(message, drawing, SelectColor(m_Color, meta), m_LengthScale, m_SphereRadius, m_Thickness, m_SizeOfAxes, m_DrawUnityAxes);
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/JointStateDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/JointStateDefaultVisualizer.cs
@@ -32,7 +32,7 @@ public class JointStateDefaultVisualizer : DrawingVisualizer<JointStateMsg>
     public override void Draw(Drawing3d drawing, JointStateMsg message, MessageMetadata meta)
     {
 #if URDF_IMPORTER
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         var color = SelectColor(m_Color, meta);
         m_RobotData.DrawGhost(drawing, message, color);
         if (m_ShowEffort)

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/MagneticFieldDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/MagneticFieldDefaultVisualizer.cs
@@ -14,7 +14,7 @@ public class MagneticFieldDefaultVisualizer : DrawingVisualizer<MagneticFieldMsg
 
     public override void Draw(Drawing3d drawing, MagneticFieldMsg message, MessageMetadata meta)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         Draw<FLU>(message, drawing, SelectColor(m_Color, meta));
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/MultiDOFJointStateDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/MultiDOFJointStateDefaultVisualizer.cs
@@ -30,7 +30,7 @@ public class MultiDOFJointStateDefaultVisualizer : DrawingVisualizer<MultiDOFJoi
     public override void Draw(Drawing3d drawing, MultiDOFJointStateMsg message, MessageMetadata meta)
     {
 #if URDF_IMPORTER
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         m_RobotData.DrawGhost(drawing, message, SelectColor(m_Color, meta));
 #endif
     }

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/RangeDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/RangeDefaultVisualizer.cs
@@ -14,7 +14,7 @@ public class RangeDefaultVisualizer : DrawingVisualizer<RangeMsg>
 
     public override void Draw(Drawing3d drawing, RangeMsg message, MessageMetadata meta)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         Draw<FLU>(message, drawing, SelectColor(m_Color, meta));
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/ScriptableObjects/LaserScanVisualizerSettings.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/ScriptableObjects/LaserScanVisualizerSettings.cs
@@ -28,9 +28,9 @@ public class LaserScanVisualizerSettings : VisualizerSettingsGeneric<LaserScanMs
     ColorModeType m_ColorMode;
     public ColorModeType ColorMode { get => m_ColorMode; set => m_ColorMode = value; }
 
-    public override void Draw(Drawing3d drawing, LaserScanMsg message, MessageMetadata meta)
+    public override void Draw(Drawing3d drawing, LaserScanMsg message, MessageMetadata meta, Transform visualizerTransform)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, visualizerTransform);
 
         PointCloudDrawing pointCloud = drawing.AddPointCloud(message.ranges.Length);
         // negate the angle because ROS coordinates are right-handed, unity coordinates are left-handed

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/ScriptableObjects/MultiEchoLaserScanVisualizerSettings.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/ScriptableObjects/MultiEchoLaserScanVisualizerSettings.cs
@@ -17,9 +17,9 @@ public class MultiEchoLaserScanVisualizerSettings : VisualizerSettingsGeneric<Mu
     float[] m_SizeRange = { 0, 100 };
     public float[] SizeRange { get => m_SizeRange; set => m_SizeRange = value; }
 
-    public override void Draw(Drawing3d drawing, MultiEchoLaserScanMsg message, MessageMetadata meta)
+    public override void Draw(Drawing3d drawing, MultiEchoLaserScanMsg message, MessageMetadata meta, Transform visualizerTransform)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, visualizerTransform);
         MultiEchoLaserScanDefaultVisualizer.Draw<FLU>(message, drawing, this);
     }
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/ScriptableObjects/PointCloud2VisualizerSettings.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/ScriptableObjects/PointCloud2VisualizerSettings.cs
@@ -60,9 +60,9 @@ public class PointCloud2VisualizerSettings : VisualizerSettingsGeneric<PointClou
     public bool UseSizeChannel { get => m_UseSizeChannel; set => m_UseSizeChannel = value; }
     bool m_UseSizeChannel = true;
 
-    public override void Draw(Drawing3d drawing, PointCloud2Msg message, MessageMetadata meta)
+    public override void Draw(Drawing3d drawing, PointCloud2Msg message, MessageMetadata meta, Transform visualizerTransform)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, visualizerTransform);
         var pointCloud = drawing.AddPointCloud((int)(message.data.Length / message.point_step));
 
         Channels = message.fields.Select(field => field.name).ToArray();

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/ScriptableObjects/PointCloudVisualizerSettings.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Sensor/ScriptableObjects/PointCloudVisualizerSettings.cs
@@ -59,9 +59,9 @@ public class PointCloudVisualizerSettings : VisualizerSettingsGeneric<PointCloud
         };
     }
 
-    public override void Draw(Drawing3d drawing, PointCloudMsg message, MessageMetadata meta)
+    public override void Draw(Drawing3d drawing, PointCloudMsg message, MessageMetadata meta, Transform visualizerTransform)
     {
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, visualizerTransform);
         PointCloudDrawing pointCloud = drawing.AddPointCloud();
         Channels = message.channels.Select(field => field.name).ToArray();
 

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Trajectory/JointTrajectoryDefaultVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/Trajectory/JointTrajectoryDefaultVisualizer.cs
@@ -35,7 +35,7 @@ public class JointTrajectoryDefaultVisualizer : DrawingVisualizer<JointTrajector
     public override void Draw(Drawing3d drawing, JointTrajectoryMsg message, MessageMetadata meta)
     {
 #if URDF_IMPORTER
-        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header);
+        drawing.SetTFTrackingSettings(m_TFTrackingSettings, message.header, transform);
         m_RobotData.DrawJointPaths(drawing, message, SelectColor(m_Color, meta), m_PathThickness);
 #endif
     }

--- a/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/Drawing3d.cs
+++ b/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/Drawing3d.cs
@@ -10,6 +10,7 @@ namespace Unity.Robotics.Visualizations
         None,
         Exact,
         TrackLatest,
+        RelativeToVisualizer,
     }
 
     [System.Serializable]
@@ -76,7 +77,7 @@ namespace Unity.Robotics.Visualizations
             }
         }
 
-        public void SetTFTrackingSettings(TFTrackingSettings tfTrackingType, HeaderMsg headerMsg)
+        public void SetTFTrackingSettings(TFTrackingSettings tfTrackingType, HeaderMsg headerMsg, Transform visualizerTransform)
         {
             switch (tfTrackingType.type)
             {
@@ -97,6 +98,9 @@ namespace Unity.Robotics.Visualizations
                 case TFTrackingType.None:
                     transform.localPosition = Vector3.zero;
                     transform.localRotation = Quaternion.identity;
+                    break;
+                case TFTrackingType.RelativeToVisualizer:
+                    transform.parent = visualizerTransform;
                     break;
             }
         }

--- a/com.unity.robotics.visualizations/Runtime/Scripts/DrawingVisualizerWithSettings.cs
+++ b/com.unity.robotics.visualizations/Runtime/Scripts/DrawingVisualizerWithSettings.cs
@@ -37,7 +37,7 @@ namespace Unity.Robotics.Visualizations
 
         public override void Draw(Drawing3d drawing, TMessage message, MessageMetadata meta)
         {
-            m_Settings.Draw(drawing, message, meta);
+            m_Settings.Draw(drawing, message, meta, transform);
         }
 
         public override Action CreateGUI(TMessage message, MessageMetadata meta)

--- a/com.unity.robotics.visualizations/Runtime/Scripts/VisualizerSettingsGeneric.cs
+++ b/com.unity.robotics.visualizations/Runtime/Scripts/VisualizerSettingsGeneric.cs
@@ -18,7 +18,7 @@ namespace Unity.Robotics.Visualizations
             return null;
         }
 
-        public virtual void Draw(Drawing3d drawing, T message, MessageMetadata meta)
+        public virtual void Draw(Drawing3d drawing, T message, MessageMetadata meta, Transform visualizerTransform)
         {
         }
     }


### PR DESCRIPTION
For users who don't want to mess around with TF messages, allow them to set up a visualizer attached to the relevant object and have the visualization move as it does.