### PR TITLE
AIRO-1888 Clearer header visualizations

### DIFF
--- a/com.unity.robotics.visualizations/Runtime/Scripts/VisualizationUtils.cs
+++ b/com.unity.robotics.visualizations/Runtime/Scripts/VisualizationUtils.cs
@@ -210,22 +210,16 @@ namespace Unity.Robotics.Visualizations
         {
             Color oldColor = UnityEngine.GUI.color;
             UnityEngine.GUI.color = new Color(0.5f, 0.85f, 0.85f);
-            if (s_HeadersExpanded)
-            {
-#if !ROS2
-                s_HeadersExpanded = GUILayout.Toggle(s_HeadersExpanded, $"Header\n  Seq: {message.seq}\n  Frame_id: {message.frame_id}\n  Time: {message.stamp.sec}s {message.stamp.nanosec}ns");
+#if ROS2
+            string headerText = s_HeadersExpanded?
+                $"Header\n  Frame_id: {message.frame_id}\n  Time: {message.stamp.sec}s {message.stamp.nanosec}ns":
+                $"Header [{message.frame_id} / {message.stamp.sec}s {message.stamp.nanosec}ns]";
 #else
-                s_HeadersExpanded = GUILayout.Toggle(s_HeadersExpanded, $"Header\n  Frame_id: {message.frame_id}\n  Time: {message.stamp.sec}s {message.stamp.nanosec}ns");
+            string headerText = s_HeadersExpanded ?
+                $"Header\n  Seq: {message.seq}\n  Frame_id: {message.frame_id}\n  Time: {message.stamp.sec}s {message.stamp.nanosec}ns" :
+                $"Header [{message.seq} / {message.frame_id} / {message.stamp.sec}s {message.stamp.nanosec}ns]";
 #endif
-            }
-            else
-            {
-#if !ROS2
-                s_HeadersExpanded = GUILayout.Toggle(s_HeadersExpanded, $"Header [{message.seq} / {message.frame_id} / {message.stamp.sec}s {message.stamp.nanosec}ns]");
-#else
-                GUILayout.Label($"Header [{message.frame_id} / {message.stamp.sec}s {message.stamp.nanosec}ns]");
-#endif
-            }
+            s_HeadersExpanded = GUILayout.Toggle(s_HeadersExpanded, headerText);
             UnityEngine.GUI.color = oldColor;
         }
 

--- a/com.unity.robotics.visualizations/Runtime/Scripts/VisualizationUtils.cs
+++ b/com.unity.robotics.visualizations/Runtime/Scripts/VisualizationUtils.cs
@@ -204,14 +204,29 @@ namespace Unity.Robotics.Visualizations
             GUILayout.EndHorizontal();
         }
 
+        static bool s_HeadersExpanded = false;
+
         public static void GUI(this HeaderMsg message)
         {
+            Color oldColor = UnityEngine.GUI.color;
+            UnityEngine.GUI.color = new Color(0.5f, 0.85f, 0.85f);
+            if (s_HeadersExpanded)
+            {
 #if !ROS2
-            GUILayout.Label($"<{message.seq} {message.frame_id} {message.stamp.ToTimestampString()}>");
+                s_HeadersExpanded = GUILayout.Toggle(s_HeadersExpanded, $"Header\n  Seq: {message.seq}\n  Frame_id: {message.frame_id}\n  Time: {message.stamp.sec}s {message.stamp.nanosec}ns");
 #else
-            GUILayout.Label($"<{message.frame_id} {message.stamp.ToTimestampString()}>");
+                s_HeadersExpanded = GUILayout.Toggle(s_HeadersExpanded, $"Header\n  Frame_id: {message.frame_id}\n  Time: {message.stamp.sec}s {message.stamp.nanosec}ns");
 #endif
-
+            }
+            else
+            {
+#if !ROS2
+                s_HeadersExpanded = GUILayout.Toggle(s_HeadersExpanded, $"Header [{message.seq} / {message.frame_id} / {message.stamp.sec}s {message.stamp.nanosec}ns]");
+#else
+                GUILayout.Label($"Header [{message.frame_id} / {message.stamp.sec}s {message.stamp.nanosec}ns]");
+#endif
+            }
+            UnityEngine.GUI.color = oldColor;
         }
 
         public static void GUITexture(this Texture2D tex)


### PR DESCRIPTION
Headers show in a unique color, are labelled "header" and can be expanded to show field labels.
The seconds field does not represent a Unix time, don't try to display them as a "date".