### PR TITLE
AIRO-1891 Time msg properties: Secs and Nsecs

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/Extensions/MessageExtensions.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Extensions/MessageExtensions.cs
@@ -119,7 +119,7 @@ namespace Unity.Robotics.ROSTCPConnector.MessageGeneration
 
         public static long ToLongTime(this TimeMsg message)
         {
-            return (long)message.sec << 32 | message.nanosec;
+            return (long)message.secs << 32 | message.nanosec;
         }
 
         public static DateTime ToDateTime(this TimeMsg message)

--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/HandwrittenMessages/msg/TimeMsg.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/HandwrittenMessages/msg/TimeMsg.cs
@@ -12,21 +12,45 @@ namespace RosMessageTypes.BuiltinInterfaces
         public const string k_RosMessageName = "std_msgs/Time";
         public override string RosMessageName => k_RosMessageName;
 
-        public uint sec;
-        public uint nanosec;
+        public uint secs;
+        public uint nsecs;
+
+        // for convenience when writing ROS2 agnostic code
+        public int sec { get => (int)secs; set => secs = (uint)value; }
+        public uint nanosec { get => nsecs; set => nsecs = value; }
 
         public TimeMsg()
         {
-            this.sec = 0;
-            this.nanosec = 0;
+            this.secs = 0;
+            this.nsecs = 0;
         }
 
-        public TimeMsg(uint sec, uint nanosec)
+        public TimeMsg(uint secs, uint nsecs)
         {
-            this.sec = sec;
-            this.nanosec = nanosec;
+            this.secs = secs;
+            this.nsecs = nsecs;
         }
 
+        public static TimeMsg Deserialize(MessageDeserializer deserializer) => new TimeMsg(deserializer);
+
+        TimeMsg(MessageDeserializer deserializer)
+        {
+            deserializer.Read(out this.secs);
+            deserializer.Read(out this.nsecs);
+        }
+
+        public override void SerializeTo(MessageSerializer serializer)
+        {
+            serializer.Write(this.secs);
+            serializer.Write(this.nsecs);
+        }
+
+        public override string ToString()
+        {
+            return "Time: " +
+            "\nsecs: " + secs.ToString() +
+            "\nnsecs: " + nsecs.ToString();
+        }
 #else
         public const string k_RosMessageName = "builtin_interfaces/Time";
         public override string RosMessageName => k_RosMessageName;
@@ -37,6 +61,10 @@ namespace RosMessageTypes.BuiltinInterfaces
         public int sec;
         //  The nanoseconds component, valid in the range [0, 10e9).
         public uint nanosec;
+
+        // for convenience when writing ROS2 agnostic code
+        public uint secs { get => (uint)sec; set => sec = (int)value; }
+        public uint nsecs { get => nsecs; set => nsecs = value; }
 
         public TimeMsg()
         {
@@ -49,7 +77,6 @@ namespace RosMessageTypes.BuiltinInterfaces
             this.sec = sec;
             this.nanosec = nanosec;
         }
-#endif
 
         public static TimeMsg Deserialize(MessageDeserializer deserializer) => new TimeMsg(deserializer);
 
@@ -71,6 +98,7 @@ namespace RosMessageTypes.BuiltinInterfaces
             "\nsec: " + sec.ToString() +
             "\nnanosec: " + nanosec.ToString();
         }
+#endif
 
 #if UNITY_EDITOR
         [UnityEditor.InitializeOnLoadMethod]

--- a/com.unity.robotics.visualizations/Runtime/Scripts/VisualizationUtils.cs
+++ b/com.unity.robotics.visualizations/Runtime/Scripts/VisualizationUtils.cs
@@ -216,8 +216,8 @@ namespace Unity.Robotics.Visualizations
                 $"Header [{message.frame_id} / {message.stamp.sec}s {message.stamp.nanosec}ns]";
 #else
             string headerText = s_HeadersExpanded ?
-                $"Header\n  Seq: {message.seq}\n  Frame_id: {message.frame_id}\n  Time: {message.stamp.sec}s {message.stamp.nanosec}ns" :
-                $"Header [{message.seq} / {message.frame_id} / {message.stamp.sec}s {message.stamp.nanosec}ns]";
+                $"Header\n  Seq: {message.seq}\n  Frame_id: {message.frame_id}\n  Time: {message.stamp.secs}s {message.stamp.nsecs}ns" :
+                $"Header [{message.seq} / {message.frame_id} / {message.stamp.secs}s {message.stamp.nsecs}ns]";
 #endif
             s_HeadersExpanded = GUILayout.Toggle(s_HeadersExpanded, headerText);
             UnityEngine.GUI.color = oldColor;


### PR DESCRIPTION
ROS1 calls the time fields "secs" and "nsecs", whereas ROS2 calls them "sec" and "nanosec".
We should accept either version.