### PR TITLE
Fixing compass asset load in standalone builds

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/GeometryCompass.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/ROSGeometry/GeometryCompass.cs
@@ -13,7 +13,8 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
 
     public class GeometryCompass : ScriptableObject
     {
-        public const string k_CompassSettingsAsset = "GeometryCompassSettings.asset";
+        public const string k_CompassSettingsName = "GeometryCompassSettings";
+        public const string k_CompassSettingsAsset = k_CompassSettingsName + ".asset";
 
         [SerializeField] CardinalDirection m_ZAxisDirection;
 
@@ -36,7 +37,7 @@ namespace Unity.Robotics.ROSTCPConnector.ROSGeometry
                 UnityEditor.AssetDatabase.SaveAssets();
             }
 #else
-            s_Instance = Resources.Load<GeometryCompass>(k_CompassSettingsAsset);
+            s_Instance = Resources.Load<GeometryCompass>(k_CompassSettingsName);
 #endif
             return s_Instance;
         }


### PR DESCRIPTION
I confirmed the previous version of the code would not work in Unity version 2021.2.18f1 - the default would end up being used instead.

## Proposed change(s)

Loading the resources asset with the name rather than the name and file extension.

### Types of change(s)

- [ x ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Created a script which would move an asset when it receives a pose message from ROS. I performed the test in the editor and noted a different result from the build. After connecting a debugger it was apparent the asset wasn't being loaded.

### Test Configuration:
- Unity Version: Unity 2021.2.18f1
- Unity machine OS + version: Ubuntu 18.04
- ROS machine OS + version: Ubuntu 18.04, ROS Melodic
- ROS–Unity communication: Local

## Checklist
- [ x ] Ensured this PR is up-to-date with the `dev` branch
- [ x ] Created this PR to target the `dev` branch
- [ x ] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments