### PR TITLE
AIRO-1941 Justing/add visualization layer support

### DIFF
--- a/com.unity.robotics.visualizations/CHANGELOG.md
+++ b/com.unity.robotics.visualizations/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
+## [0.7.2-preview] - 2022-07-11
+
+Added a Visualization Layer property to DrawingManager3d to allow developers to specify which layer the visualizations render into.
+   Defaults to UI layer, and the sensors in sensors package will set the culling mask to not sense the UI layer. 
 
 ## [0.7.0-preview] - 2022-02-01
 

--- a/com.unity.robotics.visualizations/CHANGELOG.md
+++ b/com.unity.robotics.visualizations/CHANGELOG.md
@@ -24,7 +24,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [0.7.2-preview] - 2022-07-11
 
 Added a Visualization Layer property to DrawingManager3d to allow developers to specify which layer the visualizations render into.
-   Defaults to UI layer, and the sensors in sensors package will set the culling mask to not sense the UI layer. 
+   Defaults to UI layer, and the sensors in sensors package will set the culling mask to not sense the UI layer. If you add a new layer
+   and choose that (or another builtin layer), you should deselect that layer in the culling mask of any sensors that have a camera component.
 
 ## [0.7.0-preview] - 2022-02-01
 

--- a/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/Drawing3dManager.cs
+++ b/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/Drawing3dManager.cs
@@ -35,6 +35,11 @@ namespace Unity.Robotics.Visualizations
         List<Drawing3d> m_Dirty = new List<Drawing3d>();
 
         [SerializeField]
+        DrawingLayer m_VisualizationLayer = new DrawingLayer();
+
+        public int VisualizationLayer => m_VisualizationLayer.LayerNumber;
+
+        [SerializeField]
         Material m_UnlitVertexColorMaterial;
         [SerializeField]
         Material m_UnlitColorMaterial;
@@ -68,6 +73,8 @@ namespace Unity.Robotics.Visualizations
         public static Drawing3d CreateDrawing(float duration = -1, Material material = null)
         {
             GameObject newDrawingObj = new GameObject("Drawing");
+            if (Drawing3dManager.instance.VisualizationLayer != -1)
+                newDrawingObj.layer = Drawing3dManager.instance.VisualizationLayer;
             Drawing3d newDrawing = newDrawingObj.AddComponent<Drawing3d>();
             newDrawing.Init(instance, material != null ? material : instance.UnlitVertexColorMaterial, duration);
             instance.m_Drawings.Add(newDrawing);

--- a/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/Drawing3dManager.cs
+++ b/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/Drawing3dManager.cs
@@ -73,8 +73,7 @@ namespace Unity.Robotics.Visualizations
         public static Drawing3d CreateDrawing(float duration = -1, Material material = null)
         {
             GameObject newDrawingObj = new GameObject("Drawing");
-            if (Drawing3dManager.instance.VisualizationLayer != -1)
-                newDrawingObj.layer = Drawing3dManager.instance.VisualizationLayer;
+            newDrawingObj.layer = Drawing3dManager.instance.VisualizationLayer;
             Drawing3d newDrawing = newDrawingObj.AddComponent<Drawing3d>();
             newDrawing.Init(instance, material != null ? material : instance.UnlitVertexColorMaterial, duration);
             instance.m_Drawings.Add(newDrawing);

--- a/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/DrawingLayer.cs
+++ b/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/DrawingLayer.cs
@@ -1,0 +1,30 @@
+using System;
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Unity.Robotics.Visualizations
+{
+    [Serializable]
+    public class DrawingLayer
+    {
+        public int LayerNumber = 5; // Default to builtin UI layer
+    }
+
+#if UNITY_EDITOR
+    [CustomPropertyDrawer(typeof(DrawingLayer))]
+    public class DrawingLayerPropertyDrawer : PropertyDrawer 
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, GUIContent.none, property);
+            SerializedProperty layer = property.FindPropertyRelative("LayerNumber");
+            position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
+            if (layer != null)
+                layer.intValue = EditorGUI.LayerField(position, layer.intValue);
+            EditorGUI.EndProperty();
+        }
+    }
+#endif
+}

--- a/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/DrawingLayer.cs.meta
+++ b/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/DrawingLayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4bc63722a58f2df7f8bc8c64b842f87c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/PointCloudDrawing.cs
+++ b/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/PointCloudDrawing.cs
@@ -24,6 +24,8 @@ namespace Unity.Robotics.Visualizations
                 newDrawingObj.transform.parent = parent.transform;
                 newDrawingObj.transform.localPosition = Vector3.zero;
                 newDrawingObj.transform.localRotation = Quaternion.identity;
+                if (Drawing3dManager.instance.VisualizationLayer != -1)
+                    newDrawingObj.layer = Drawing3dManager.instance.VisualizationLayer;
             }
             PointCloudDrawing newDrawing = newDrawingObj.AddComponent<PointCloudDrawing>();
             newDrawing.SetCapacity(numPoints);

--- a/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/PointCloudDrawing.cs
+++ b/com.unity.robotics.visualizations/Runtime/Drawing3d/Scripts/PointCloudDrawing.cs
@@ -24,8 +24,7 @@ namespace Unity.Robotics.Visualizations
                 newDrawingObj.transform.parent = parent.transform;
                 newDrawingObj.transform.localPosition = Vector3.zero;
                 newDrawingObj.transform.localRotation = Quaternion.identity;
-                if (Drawing3dManager.instance.VisualizationLayer != -1)
-                    newDrawingObj.layer = Drawing3dManager.instance.VisualizationLayer;
+                newDrawingObj.layer = Drawing3dManager.instance.VisualizationLayer;
             }
             PointCloudDrawing newDrawing = newDrawingObj.AddComponent<PointCloudDrawing>();
             newDrawing.SetCapacity(numPoints);

--- a/com.unity.robotics.visualizations/package.json
+++ b/com.unity.robotics.visualizations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.robotics.visualizations",
-  "version": "0.7.1-preview",
+  "version": "0.7.2-preview",
   "displayName": "Unity Robotics Visualizations",
   "description": "Components for displaying specific ROS messages",
   "unity": "2020.2",

--- a/com.unity.robotics.visualizations/package.json
+++ b/com.unity.robotics.visualizations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.robotics.visualizations",
-  "version": "0.7.2-preview",
+  "version": "0.7.1-preview",
   "displayName": "Unity Robotics Visualizations",
   "description": "Components for displaying specific ROS messages",
   "unity": "2020.2",


### PR DESCRIPTION
## Proposed change(s)

PR adds a property to Drawing3dManager to allow the developer to specify the layer to render into.
This PR just adds the support to specify the layer, and it defaults to UI.
A followup PR will be needed for RoboticsSensors that use cameras, to optionally grab this layer index (if the visualizations package is present) and set the layer mask appropriately.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

https://jira.unity3d.com/browse/AIRO-1941

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment.

### Test Configuration:
- Unity Version: [e.g. Unity 2020.2.0f1]
- Unity machine OS + version: [e.g. Windows 10]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Noetic]
- ROS–Unity communication: [e.g. Docker]

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [ ] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments