### PR TITLE
Clear static data on destory, fixes error during scene change

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
+++ b/com.unity.robotics.ros-tcp-connector/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+Clear static data on destroy
+
 ### Upgrade Notes
 
 ### Known Issues

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/HudPanel.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/HudPanel.cs
@@ -22,7 +22,8 @@ namespace Unity.Robotics.ROSTCPConnector
         static SortedList<int, IHudTab> s_HUDTabs = new SortedList<int, IHudTab>();
         static SortedList<int, Action> s_HeaderContents = new SortedList<int, Action>();
         static List<HudWindow> s_ActiveWindows = new List<HudWindow>();
-        static int s_NextWindowID = 101;
+        const int INITIAL_NEXT_WINDOW_ID = 101;
+        static int s_NextWindowID = INITIAL_NEXT_WINDOW_ID;
 
         // ROS Message variables
         internal bool isEnabled;
@@ -123,6 +124,13 @@ namespace Unity.Robotics.ROSTCPConnector
 
             s_HeaderContents.Add(index, headerContent);
         }
+        public static void ClearStaticContent()
+        {
+            s_HUDTabs.Clear();
+            s_HeaderContents.Clear();
+            s_ActiveWindows.Clear();
+            s_NextWindowID = INITIAL_NEXT_WINDOW_ID;
+        }
 
         public static void AddWindow(HudWindow window)
         {
@@ -204,24 +212,5 @@ namespace Unity.Robotics.ROSTCPConnector
 
             return result;
         }
-
-#if UNITY_EDITOR
-        // automatically clear all static content on pressing play
-        [UnityEditor.InitializeOnLoadMethod]
-        static void InitializeOnLoad()
-        {
-            UnityEditor.EditorApplication.playModeStateChanged += OnPlayMode;
-        }
-
-        static void OnPlayMode(UnityEditor.PlayModeStateChange change)
-        {
-            if (change == UnityEditor.PlayModeStateChange.ExitingEditMode)
-            {
-                s_HUDTabs.Clear();
-                s_HeaderContents.Clear();
-                s_ActiveWindows.Clear();
-            }
-        }
-#endif
     }
 }

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -491,6 +491,11 @@ namespace Unity.Robotics.ROSTCPConnector
             if (ConnectOnStart)
                 Connect();
         }
+        void OnDestroy()
+        {
+            HudPanel.ClearStaticContent();
+            Disconnect();
+        }
 
         public void Connect(string ipAddress, int port)
         {

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/TFSystem.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/TFSystem.cs
@@ -129,6 +129,14 @@ public class TFSystem
         return instance;
     }
 
+    public static void ClearStaticData()
+    {
+        if (instance != null)
+        {
+            instance.m_TFTopics.Clear();
+            instance = null;
+        }
+    }
     public IEnumerable<string> GetTransformNames(string tfTopic = "/tf")
     {
         return GetOrCreateTFTopic(tfTopic).GetTransformNames();

--- a/com.unity.robotics.visualizations/CHANGELOG.md
+++ b/com.unity.robotics.visualizations/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+Clear static data on destroy
+
 ### Upgrade Notes
 
 ### Known Issues

--- a/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/TFSystemVisualizer.cs
+++ b/com.unity.robotics.visualizations/Runtime/DefaultVisualizers/TFSystemVisualizer.cs
@@ -20,6 +20,10 @@ namespace Unity.Robotics.Visualizations
             if (color.a == 0)
                 color.a = 1;
         }
+        void OnDestroy()
+        {
+            TFSystem.ClearStaticData();
+        }
 
         void EnsureSettings(TFStream stream)
         {


### PR DESCRIPTION
## Proposed change(s)

Clear static data on destory, fixes error during scene change. 

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

This fix #315. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment.

### Test Configuration:
- Unity Version: Unity 2022.3.58f1c1
- Unity machine OS + version: Windows 11
- ROS machine OS + version: WSL2 Ubuntu 22.04
- ROS–Unity communication: ROS-TCP-Endpoint

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments