### PR TITLE
Add ROS2 Action client and server support

### DIFF
--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces.meta
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 684de9439bfc12c409ea25c6fb7d611a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action.meta
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b55dcaf5b037944c9eedef3415b66cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciFeedback.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciFeedback.cs
@@ -1,0 +1,47 @@
+using System;
+using Unity.Robotics.ROSTCPConnector.MessageGeneration;
+
+namespace RosMessageTypes.ActionTutorialsInterfaces
+{
+    [Serializable]
+    public class FibonacciFeedback : Message
+    {
+        public const string k_RosMessageName = "action_tutorials_interfaces/Fibonacci_Feedback";
+        public override string RosMessageName => k_RosMessageName;
+
+        public int[] partial_sequence;
+
+        public FibonacciFeedback()
+        {
+            this.partial_sequence = new int[0];
+        }
+
+        public FibonacciFeedback(int[] partial_sequence)
+        {
+            this.partial_sequence = partial_sequence;
+        }
+
+        public static FibonacciFeedback Deserialize(MessageDeserializer deserializer) => new FibonacciFeedback(deserializer);
+
+        private FibonacciFeedback(MessageDeserializer deserializer)
+        {
+            deserializer.Read(out this.partial_sequence, sizeof(int), deserializer.ReadLength());
+        }
+
+        public override void SerializeTo(MessageSerializer serializer)
+        {
+            serializer.WriteLength(this.partial_sequence);
+            serializer.Write(this.partial_sequence);
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.InitializeOnLoadMethod]
+#else
+        [UnityEngine.RuntimeInitializeOnLoadMethod]
+#endif
+        public static void Register()
+        {
+            MessageRegistry.Register(k_RosMessageName, Deserialize);
+        }
+    }
+}

--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciFeedback.cs.meta
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciFeedback.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9b7aa11f45efedd449674f25b4140411

--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciFeedbackMessage.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciFeedbackMessage.cs
@@ -1,0 +1,55 @@
+using System;
+using Unity.Robotics.ROSTCPConnector.MessageGeneration;
+
+namespace RosMessageTypes.ActionTutorialsInterfaces
+{
+    /// <summary>
+    /// The wire-level FeedbackMessage for Fibonacci actions.
+    /// Layout: unique_identifier_msgs/UUID goal_id + Fibonacci_Feedback feedback.
+    /// </summary>
+    [Serializable]
+    public class FibonacciFeedbackMessage : Message
+    {
+        public const string k_RosMessageName = "action_tutorials_interfaces/Fibonacci_FeedbackMessage";
+        // The endpoint may also report this type with /action/ in the path
+        // when it refreshes the topic list from the ROS2 graph.
+        public const string k_RosMessageNameAlt = "action_tutorials_interfaces/action/Fibonacci_FeedbackMessage";
+        public override string RosMessageName => k_RosMessageName;
+
+        public byte[] goal_id = new byte[16];
+        public FibonacciFeedback feedback = new FibonacciFeedback();
+
+        public FibonacciFeedbackMessage() { }
+
+        public static FibonacciFeedbackMessage Deserialize(MessageDeserializer deserializer)
+            => new FibonacciFeedbackMessage(deserializer);
+
+        private FibonacciFeedbackMessage(MessageDeserializer deserializer)
+        {
+            // UUID is uint8[16] — 16 raw bytes, no length prefix.
+            goal_id = new byte[16];
+            for (int i = 0; i < 16; i++)
+                deserializer.Read(out goal_id[i]);
+
+            // Feedback body follows inline.
+            feedback = FibonacciFeedback.Deserialize(deserializer);
+        }
+
+        public override void SerializeTo(MessageSerializer serializer)
+        {
+            serializer.Write(goal_id);
+            feedback.SerializeTo(serializer);
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.InitializeOnLoadMethod]
+#else
+        [UnityEngine.RuntimeInitializeOnLoadMethod]
+#endif
+        public static void Register()
+        {
+            MessageRegistry.Register(k_RosMessageName, Deserialize);
+            MessageRegistry.Register(k_RosMessageNameAlt, Deserialize);
+        }
+    }
+}

--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciFeedbackMessage.cs.meta
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciFeedbackMessage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 74456a0e45846244d9ea4126e08f71e5

--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciGoal.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciGoal.cs
@@ -1,0 +1,46 @@
+using System;
+using Unity.Robotics.ROSTCPConnector.MessageGeneration;
+
+namespace RosMessageTypes.ActionTutorialsInterfaces
+{
+    [Serializable]
+    public class FibonacciGoal : Message
+    {
+        public const string k_RosMessageName = "action_tutorials_interfaces/Fibonacci_Goal";
+        public override string RosMessageName => k_RosMessageName;
+
+        public int order;
+
+        public FibonacciGoal()
+        {
+            this.order = 0;
+        }
+
+        public FibonacciGoal(int order)
+        {
+            this.order = order;
+        }
+
+        public static FibonacciGoal Deserialize(MessageDeserializer deserializer) => new FibonacciGoal(deserializer);
+
+        private FibonacciGoal(MessageDeserializer deserializer)
+        {
+            deserializer.Read(out this.order);
+        }
+
+        public override void SerializeTo(MessageSerializer serializer)
+        {
+            serializer.Write(this.order);
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.InitializeOnLoadMethod]
+#else
+        [UnityEngine.RuntimeInitializeOnLoadMethod]
+#endif
+        public static void Register()
+        {
+            MessageRegistry.Register(k_RosMessageName, Deserialize);
+        }
+    }
+}

--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciGoal.cs.meta
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciGoal.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 887590542df5ade42bd75dbe0eb0b9e6

--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciResult.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciResult.cs
@@ -1,0 +1,47 @@
+using System;
+using Unity.Robotics.ROSTCPConnector.MessageGeneration;
+
+namespace RosMessageTypes.ActionTutorialsInterfaces
+{
+    [Serializable]
+    public class FibonacciResult : Message
+    {
+        public const string k_RosMessageName = "action_tutorials_interfaces/Fibonacci_Result";
+        public override string RosMessageName => k_RosMessageName;
+
+        public int[] sequence;
+
+        public FibonacciResult()
+        {
+            this.sequence = new int[0];
+        }
+
+        public FibonacciResult(int[] sequence)
+        {
+            this.sequence = sequence;
+        }
+
+        public static FibonacciResult Deserialize(MessageDeserializer deserializer) => new FibonacciResult(deserializer);
+
+        private FibonacciResult(MessageDeserializer deserializer)
+        {
+            deserializer.Read(out this.sequence, sizeof(int), deserializer.ReadLength());
+        }
+
+        public override void SerializeTo(MessageSerializer serializer)
+        {
+            serializer.WriteLength(this.sequence);
+            serializer.Write(this.sequence);
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.InitializeOnLoadMethod]
+#else
+        [UnityEngine.RuntimeInitializeOnLoadMethod]
+#endif
+        public static void Register()
+        {
+            MessageRegistry.Register(k_RosMessageName, Deserialize);
+        }
+    }
+}

--- a/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciResult.cs.meta
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/Messages/ActionTutorialsInterfaces/action/FibonacciResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 90561f1ab67d0e146abaf2dd8d15e4a2

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSActionClient.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSActionClient.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Unity.Robotics.ROSTCPConnector.MessageGeneration;
+using UnityEngine;
+
+namespace Unity.Robotics.ROSTCPConnector
+{
+    /// <summary>
+    /// Client-side handle for a ROS2 Action. Sends goals, receives feedback,
+    /// awaits results, and cancels goals through the patched ROS-TCP-Endpoint.
+    /// Requires the comoc/ROS-TCP-Endpoint fork (main-ros2 branch).
+    /// </summary>
+    public class ROSActionClient<TGoal, TResult, TFeedback>
+        where TGoal : Message, new()
+        where TResult : Message, new()
+        where TFeedback : Message, new()
+    {
+        readonly ROSConnection m_Connection;
+        readonly string m_ActionName;
+        readonly string m_ActionType;
+        bool m_Registered;
+
+        readonly Dictionary<string, ActionGoalHandle<TResult, TFeedback>> m_GoalHandles =
+            new Dictionary<string, ActionGoalHandle<TResult, TFeedback>>();
+
+        public ROSActionClient(ROSConnection connection, string actionName, string actionType)
+        {
+            m_Connection = connection;
+            m_ActionName = actionName;
+            m_ActionType = actionType;
+        }
+
+        public async Task<ActionGoalHandle<TResult, TFeedback>> SendGoal(TGoal goal)
+        {
+            EnsureRegistered();
+
+            var (srvId, pauser) = m_Connection.AllocateServiceRequest();
+
+            m_Connection.QueueSysCommand(
+                SysCommand.k_SysCommand_ActionSendGoal,
+                new SysCommand_ActionGoalOp { action_name = m_ActionName, srv_id = srvId });
+            m_Connection.QueueRawMessage(m_ActionName, goal);
+
+            byte[] responseBytes = (byte[])await pauser.PauseUntilResumed();
+
+            if (responseBytes == null || responseBytes.Length < 16)
+            {
+                Debug.LogWarning($"ROSActionClient: invalid send_goal response for {m_ActionName}");
+                return null;
+            }
+
+            byte[] goalId = new byte[16];
+            Array.Copy(responseBytes, 0, goalId, 0, 16);
+
+            // CDR header (4 bytes) + bool accepted (1 byte) starts at offset 16
+            byte[] cdrResponse = new byte[responseBytes.Length - 16];
+            Array.Copy(responseBytes, 16, cdrResponse, 0, cdrResponse.Length);
+            bool accepted = cdrResponse.Length > 4 && cdrResponse[4] != 0;
+
+            var handle = new ActionGoalHandle<TResult, TFeedback>(
+                m_Connection, m_ActionName, goalId, accepted);
+
+            if (accepted)
+                m_GoalHandles[BytesToHex(goalId)] = handle;
+
+            return handle;
+        }
+
+        internal void OnFeedbackReceived(byte[] goalIdBytes, TFeedback feedback)
+        {
+            string key = BytesToHex(goalIdBytes);
+            if (m_GoalHandles.TryGetValue(key, out var handle))
+                handle.InvokeFeedback(feedback);
+        }
+
+        void EnsureRegistered()
+        {
+            if (m_Registered)
+                return;
+            m_Registered = true;
+
+            m_Connection.QueueSysCommand(
+                SysCommand.k_SysCommand_ActionClient,
+                new SysCommand_ActionRegistration
+                {
+                    action_name = m_ActionName,
+                    action_type = m_ActionType
+                });
+        }
+
+        /// <summary>
+        /// Subscribe to the feedback topic using a FeedbackMessage type that
+        /// contains both goal_id (byte[16]) and feedback (TFeedback).
+        /// Call this after creating the client to enable FeedbackReceived
+        /// events on goal handles.
+        ///
+        /// Example:
+        ///   client.RegisterFeedbackSubscription&lt;FibonacciFeedbackMessage&gt;(
+        ///       msg => msg.goal_id, msg => msg.feedback);
+        /// </summary>
+        public void RegisterFeedbackSubscription<TFeedbackMessage>(
+            Func<TFeedbackMessage, byte[]> getGoalId,
+            Func<TFeedbackMessage, TFeedback> getFeedback)
+            where TFeedbackMessage : Message, new()
+        {
+            string feedbackTopic = m_ActionName + "/_action/feedback";
+            // Use the short type name (without /action/) for the __subscribe
+            // syscommand — this is what the endpoint uses to resolve the type.
+            // The endpoint sends feedback with this short name, but __topic_list
+            // reports the full /action/ path, causing a type mismatch in
+            // Subscribe<T>. Using SubscribeByMessageName with the short name
+            // avoids the generic type check.
+            string feedbackTypeName = m_ActionType + "_FeedbackMessage";
+            m_Connection.SubscribeByMessageName(feedbackTopic, feedbackTypeName, (Message msg) =>
+            {
+                if (msg is TFeedbackMessage typedMsg)
+                {
+                    byte[] goalId = getGoalId(typedMsg);
+                    TFeedback feedback = getFeedback(typedMsg);
+                    OnFeedbackReceived(goalId, feedback);
+                }
+            });
+        }
+
+        static string BytesToHex(byte[] bytes)
+        {
+            return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
+        }
+    }
+
+    /// <summary>
+    /// Handle to a single in-flight action goal.
+    /// </summary>
+    public class ActionGoalHandle<TResult, TFeedback>
+        where TResult : Message, new()
+        where TFeedback : Message, new()
+    {
+        readonly ROSConnection m_Connection;
+        readonly string m_ActionName;
+
+        public byte[] GoalId { get; }
+        public bool Accepted { get; }
+        public event Action<TFeedback> FeedbackReceived;
+
+        internal ActionGoalHandle(ROSConnection connection, string actionName,
+            byte[] goalId, bool accepted)
+        {
+            m_Connection = connection;
+            m_ActionName = actionName;
+            GoalId = goalId;
+            Accepted = accepted;
+        }
+
+        public async Task<TResult> GetResult()
+        {
+            var (srvId, pauser) = m_Connection.AllocateServiceRequest();
+
+            m_Connection.QueueSysCommand(
+                SysCommand.k_SysCommand_ActionGetResult,
+                new SysCommand_ActionGoalOp { action_name = m_ActionName, srv_id = srvId });
+
+            var request = new GetResultRequestProxy { goal_id = GoalId };
+            m_Connection.QueueRawMessage(m_ActionName, request);
+
+            byte[] responseBytes = (byte[])await pauser.PauseUntilResumed();
+
+            if (responseBytes == null || responseBytes.Length == 0)
+                return default;
+
+            // GetResult_Response CDR layout:
+            //   [4 bytes CDR header (00 01 00 00)]
+            //   [1 byte int8 status]
+            //   [3 bytes alignment padding to 4-byte boundary]
+            //   [Result CDR body (WITHOUT its own CDR header)]
+            //
+            // We need to strip the CDR header + status + padding, then
+            // prepend a fresh CDR header so the deserializer sees a
+            // well-formed CDR stream for TResult.
+            const int headerSize = 4;  // CDR encapsulation header
+            const int statusSize = 1;  // int8 status
+            const int padSize = 3;     // alignment to 4-byte boundary
+            int skipBytes = headerSize + statusSize + padSize;
+
+            if (responseBytes.Length <= skipBytes)
+                return default;
+
+            // Build a new byte array: CDR header + Result body
+            byte[] resultCdr = new byte[4 + (responseBytes.Length - skipBytes)];
+            resultCdr[0] = 0x00; resultCdr[1] = 0x01; // CDR_LE
+            resultCdr[2] = 0x00; resultCdr[3] = 0x00;
+            Array.Copy(responseBytes, skipBytes, resultCdr, 4,
+                responseBytes.Length - skipBytes);
+
+            var deserializer = new MessageDeserializer();
+            return deserializer.DeserializeMessage<TResult>(resultCdr);
+        }
+
+        public async Task<bool> Cancel()
+        {
+            var (srvId, pauser) = m_Connection.AllocateServiceRequest();
+
+            m_Connection.QueueSysCommand(
+                SysCommand.k_SysCommand_ActionCancelGoal,
+                new SysCommand_ActionGoalOp { action_name = m_ActionName, srv_id = srvId });
+
+            var request = new CancelGoalRequestProxy { goal_id = GoalId };
+            m_Connection.QueueRawMessage(m_ActionName, request);
+
+            byte[] responseBytes = (byte[])await pauser.PauseUntilResumed();
+            if (responseBytes == null || responseBytes.Length < 5)
+                return false;
+
+            // CDR header (4) + int8 return_code. ERROR_NONE = 0.
+            return responseBytes[4] == 0;
+        }
+
+        internal void InvokeFeedback(TFeedback feedback)
+        {
+            FeedbackReceived?.Invoke(feedback);
+        }
+    }
+
+    internal class GetResultRequestProxy : Message
+    {
+        public byte[] goal_id = new byte[16];
+        public override string RosMessageName => "";
+
+        public override void SerializeTo(MessageSerializer serializer)
+        {
+            serializer.Write(goal_id);
+        }
+    }
+
+    internal class CancelGoalRequestProxy : Message
+    {
+        public byte[] goal_id = new byte[16];
+        public override string RosMessageName => "action_msgs/CancelGoal";
+
+        public override void SerializeTo(MessageSerializer serializer)
+        {
+            serializer.Write(goal_id);
+            serializer.Write(0);        // stamp.sec
+            serializer.Write((uint)0);  // stamp.nanosec
+        }
+    }
+}

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSActionClient.cs.meta
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSActionClient.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 75fe46779a0a2bf448942ff4c203479d

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSActionServer.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSActionServer.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using Unity.Robotics.ROSTCPConnector.MessageGeneration;
+using UnityEngine;
+
+namespace Unity.Robotics.ROSTCPConnector
+{
+    /// <summary>
+    /// Server-side handle for a ROS2 Action implemented in Unity.
+    /// When a ROS2 action client sends a goal, the endpoint forwards it
+    /// to Unity via __request/__response. Unity processes the goal,
+    /// publishes feedback, and sends the result back.
+    ///
+    /// Requires the comoc/ROS-TCP-Endpoint fork (main-ros2 branch).
+    /// </summary>
+    public class ROSActionServer<TGoal, TResult, TFeedback>
+        where TGoal : Message, new()
+        where TResult : Message, new()
+        where TFeedback : Message, new()
+    {
+        readonly ROSConnection m_Connection;
+        readonly string m_ActionName;
+        readonly string m_ActionType;
+        bool m_Registered;
+
+        /// <summary>
+        /// Fired when a ROS2 action client sends a goal. The handler
+        /// receives the goal and a handle to publish feedback and set
+        /// the result.
+        /// </summary>
+        public event Action<TGoal, ActionServerGoalHandle<TResult, TFeedback>> GoalReceived;
+
+        // Active goals keyed by hex UUID.
+        readonly Dictionary<string, ActiveGoal> m_ActiveGoals =
+            new Dictionary<string, ActiveGoal>();
+
+        struct ActiveGoal
+        {
+            public int SrvId;
+            public ActionServerGoalHandle<TResult, TFeedback> Handle;
+        }
+
+        public ROSActionServer(ROSConnection connection, string actionName, string actionType)
+        {
+            m_Connection = connection;
+            m_ActionName = actionName;
+            m_ActionType = actionType;
+        }
+
+        /// <summary>
+        /// Register the action server with the endpoint. Called
+        /// automatically by ROSConnection.CreateActionServer, but can
+        /// also be called manually if needed.
+        /// </summary>
+        public void EnsureRegistered()
+        {
+            if (m_Registered)
+                return;
+            m_Registered = true;
+
+            m_Connection.QueueSysCommand(
+                SysCommand.k_SysCommand_ActionServer,
+                new SysCommand_ActionRegistration
+                {
+                    action_name = m_ActionName,
+                    action_type = m_ActionType
+                });
+        }
+
+        /// <summary>
+        /// Called by ROSConnection when a __request arrives whose
+        /// destination matches this action's name. The payload is
+        /// 16-byte UUID + CDR Goal body.
+        /// </summary>
+        internal void OnGoalRequest(int srvId, byte[] payload)
+        {
+            if (payload == null || payload.Length < 16)
+            {
+                Debug.LogWarning($"ROSActionServer: invalid goal payload for {m_ActionName}");
+                return;
+            }
+
+            byte[] goalId = new byte[16];
+            Array.Copy(payload, 0, goalId, 0, 16);
+
+            byte[] goalCdr = new byte[payload.Length - 16];
+            Array.Copy(payload, 16, goalCdr, 0, goalCdr.Length);
+
+            // Deserialize the Goal body.
+            var deserializer = new MessageDeserializer();
+            TGoal goal = deserializer.DeserializeMessage<TGoal>(goalCdr);
+
+            var handle = new ActionServerGoalHandle<TResult, TFeedback>(
+                m_Connection, m_ActionName, goalId, srvId);
+
+            string key = BytesToHex(goalId);
+            m_ActiveGoals[key] = new ActiveGoal { SrvId = srvId, Handle = handle };
+
+            GoalReceived?.Invoke(goal, handle);
+        }
+
+        /// <summary>
+        /// Remove a goal from the active set after result is sent.
+        /// Called by ActionServerGoalHandle.SetResult.
+        /// </summary>
+        internal void RemoveGoal(byte[] goalId)
+        {
+            m_ActiveGoals.Remove(BytesToHex(goalId));
+        }
+
+        static string BytesToHex(byte[] bytes)
+        {
+            return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
+        }
+    }
+
+    /// <summary>
+    /// Handle for a single goal being executed by Unity.
+    /// </summary>
+    public class ActionServerGoalHandle<TResult, TFeedback>
+        where TResult : Message, new()
+        where TFeedback : Message, new()
+    {
+        readonly ROSConnection m_Connection;
+        readonly string m_ActionName;
+        readonly int m_SrvId;
+
+        public byte[] GoalId { get; }
+
+        internal ActionServerGoalHandle(ROSConnection connection, string actionName,
+            byte[] goalId, int srvId)
+        {
+            m_Connection = connection;
+            m_ActionName = actionName;
+            GoalId = goalId;
+            m_SrvId = srvId;
+        }
+
+        /// <summary>
+        /// Publish feedback for this goal. The endpoint forwards it
+        /// to the ROS2 action client via goal_handle.publish_feedback().
+        /// </summary>
+        public void PublishFeedback(TFeedback feedback)
+        {
+            string uuidHex = BitConverter.ToString(GoalId).Replace("-", "").ToLowerInvariant();
+
+            m_Connection.QueueSysCommand(
+                SysCommand.k_SysCommand_ActionPublishFeedback,
+                new SysCommand_ActionFeedback
+                {
+                    action_name = m_ActionName,
+                    goal_uuid_hex = uuidHex
+                });
+            m_Connection.QueueRawMessage(m_ActionName, feedback);
+        }
+
+        /// <summary>
+        /// Set the final result and complete this goal. The endpoint's
+        /// execute_callback unblocks, calls goal_handle.succeed(),
+        /// and returns the result to the ROS2 action client.
+        /// </summary>
+        public void SetResult(TResult result)
+        {
+            // Send __response{srv_id} + CDR Result body.
+            // QueueSysCommand is public on ROSConnection.
+            m_Connection.QueueSysCommand(
+                SysCommand.k_SysCommand_ServiceResponse,
+                new SysCommand_Service { srv_id = m_SrvId });
+            m_Connection.QueueRawMessage(m_ActionName, result);
+        }
+    }
+}

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSActionServer.cs.meta
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSActionServer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4f46d6d822a77cd47a31fb41dc34b3fd

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs
@@ -105,6 +105,39 @@ namespace Unity.Robotics.ROSTCPConnector
         int m_NextSrvID = 101;
         Dictionary<int, TaskPauser> m_ServicesWaiting = new Dictionary<int, TaskPauser>();
 
+        /// <summary>
+        /// Allocate a service request ID and create a TaskPauser that will be
+        /// resumed when the matching __response arrives. Used internally by
+        /// ROSActionClient and ROSActionServer to share the existing service
+        /// request/response infrastructure for action calls.
+        /// </summary>
+        internal (int srvId, TaskPauser pauser) AllocateServiceRequest()
+        {
+            var pauser = new TaskPauser();
+            int srvId;
+            lock (m_ServiceRequestLock)
+            {
+                srvId = m_NextSrvID++;
+                m_ServicesWaiting.Add(srvId, pauser);
+            }
+            return (srvId, pauser);
+        }
+
+        /// <summary>
+        /// Serialize a Message as a raw data frame (destination + CDR payload)
+        /// and enqueue it. Used by ROSActionClient/Server to send the data
+        /// frame that follows an action syscommand, without triggering
+        /// Publish()'s publisher-registration check.
+        /// </summary>
+        internal void QueueRawMessage(string destination, Message message)
+        {
+            m_MessageSerializer.Clear();
+            m_MessageSerializer.Write(destination);
+            m_MessageSerializer.SerializeMessageWithLength(message);
+            m_OutgoingMessageQueue.Enqueue(
+                new SysCommandSender(m_MessageSerializer.GetBytesSequence()));
+        }
+
         public bool listenForTFMessages = true;
 
         float m_LastMessageReceivedRealtime;
@@ -319,6 +352,77 @@ namespace Unity.Robotics.ROSTCPConnector
             return result;
         }
 
+        // --- Action support ---
+
+        // Registered action servers, keyed by action name.
+        Dictionary<string, object> m_ActionServers = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Create an Action client for calling a ROS2 action server.
+        /// Requires the patched comoc/ROS-TCP-Endpoint (main-ros2 branch).
+        /// </summary>
+        public ROSActionClient<TGoal, TResult, TFeedback> CreateActionClient<TGoal, TResult, TFeedback>(
+            string actionName, string actionType = null)
+            where TGoal : Message, new()
+            where TResult : Message, new()
+            where TFeedback : Message, new()
+        {
+            if (string.IsNullOrEmpty(actionType))
+            {
+                // Derive from TGoal's RosMessageName by stripping the _Goal suffix
+                // e.g. "example_interfaces/Fibonacci_Goal" -> "example_interfaces/Fibonacci"
+                string goalName = MessageRegistry.GetRosMessageName<TGoal>();
+                if (goalName.EndsWith("_Goal"))
+                    actionType = goalName.Substring(0, goalName.Length - 5);
+                else
+                    actionType = goalName;
+            }
+            return new ROSActionClient<TGoal, TResult, TFeedback>(this, actionName, actionType);
+        }
+
+        /// <summary>
+        /// Create an Action server implemented in Unity.
+        /// Requires the patched comoc/ROS-TCP-Endpoint (main-ros2 branch).
+        /// </summary>
+        public ROSActionServer<TGoal, TResult, TFeedback> CreateActionServer<TGoal, TResult, TFeedback>(
+            string actionName, string actionType = null)
+            where TGoal : Message, new()
+            where TResult : Message, new()
+            where TFeedback : Message, new()
+        {
+            if (string.IsNullOrEmpty(actionType))
+            {
+                string goalName = MessageRegistry.GetRosMessageName<TGoal>();
+                if (goalName.EndsWith("_Goal"))
+                    actionType = goalName.Substring(0, goalName.Length - 5);
+                else
+                    actionType = goalName;
+            }
+            var server = new ROSActionServer<TGoal, TResult, TFeedback>(this, actionName, actionType);
+            m_ActionServers[actionName] = server;
+            server.EnsureRegistered();
+            return server;
+        }
+
+        /// <summary>
+        /// Route a __request payload to an action server if the destination
+        /// matches a registered action. Returns true if handled.
+        /// Called from the syscommand dispatcher.
+        /// </summary>
+        internal bool TryRouteToActionServer(int srvId, string destination, byte[] data)
+        {
+            if (m_ActionServers.TryGetValue(destination, out var serverObj))
+            {
+                // serverObj is ROSActionServer<,,> but we stored it as object.
+                // Use reflection to call OnGoalRequest.
+                var method = serverObj.GetType().GetMethod("OnGoalRequest",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                method?.Invoke(serverObj, new object[] { srvId, data });
+                return true;
+            }
+            return false;
+        }
+
         public void GetTopicList(Action<string[]> callback)
         {
             m_TopicsListCallbacks.Add(callback);
@@ -443,7 +547,7 @@ namespace Unity.Robotics.ROSTCPConnector
             if (_instance == null)
             {
                 // Prefer to use the ROSConnection in the scene, if any
-                _instance = FindObjectOfType<ROSConnection>();
+                _instance = FindAnyObjectByType<ROSConnection>();
                 if (_instance != null)
                     return _instance;
 
@@ -684,10 +788,16 @@ namespace Unity.Robotics.ROSTCPConnector
                     {
                         var serviceCommand = JsonUtility.FromJson<SysCommand_Service>(json);
 
-                        // the next incoming message will be a request for a Unity service, so set a special callback to process it
+                        // the next incoming message will be a request for a Unity service
+                        // (or an action goal from the endpoint's RosActionServer),
+                        // so set a special callback to process it
                         m_SpecialIncomingMessageHandler = (string serviceTopic, byte[] requestBytes) =>
                         {
                             m_SpecialIncomingMessageHandler = null;
+
+                            // Try action servers first (they use the same __request mechanism).
+                            if (TryRouteToActionServer(serviceCommand.srv_id, serviceTopic, requestBytes))
+                                return;
 
                             RosTopicState topicState = GetTopic(serviceTopic);
                             if (topicState == null)

--- a/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/SysCommand.cs
+++ b/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/SysCommand.cs
@@ -23,6 +23,15 @@ namespace Unity.Robotics.ROSTCPConnector
         public const string k_SysCommand_RemoveRosService = "__remove_ros_service";
         public const string k_SysCommand_RemoveUnityService = "__remove_unity_service";
 
+        // Action support - requires patched ROS-TCP-Endpoint
+        // (comoc/ROS-TCP-Endpoint, main-ros2 branch)
+        public const string k_SysCommand_ActionClient = "__action_client";
+        public const string k_SysCommand_ActionSendGoal = "__action_send_goal";
+        public const string k_SysCommand_ActionGetResult = "__action_get_result";
+        public const string k_SysCommand_ActionCancelGoal = "__action_cancel_goal";
+        public const string k_SysCommand_ActionServer = "__action_server";
+        public const string k_SysCommand_ActionPublishFeedback = "__action_publish_feedback";
+
         public abstract string Command
         {
             get;
@@ -110,5 +119,24 @@ namespace Unity.Robotics.ROSTCPConnector
         public string message_name;
         public int queue_size;
         public bool latch;
+    }
+
+    // Action support structures
+    public struct SysCommand_ActionRegistration
+    {
+        public string action_name;
+        public string action_type;
+    }
+
+    public struct SysCommand_ActionGoalOp
+    {
+        public string action_name;
+        public int srv_id;
+    }
+
+    public struct SysCommand_ActionFeedback
+    {
+        public string action_name;
+        public string goal_uuid_hex;
     }
 }


### PR DESCRIPTION
## Proposed change(s)

Add C# Action client and server classes that bridge ROS2 Actions through the TCP connection. Works with a patched ROS-TCP-Endpoint ([comoc/ROS-TCP-Endpoint PR #178](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/pull/178)) that adds the corresponding Python-side syscommands.

### Changes

**New classes:**
- ROSActionClient<TGoal, TResult, TFeedback> — async SendGoal, feedback events, GetResult, Cancel
- ROSActionServer<TGoal, TResult, TFeedback> — GoalReceived event, PublishFeedback, SetResult
- ActionGoalHandle / ActionServerGoalHandle for per-goal state management

**ROSConnection integration:**
- CreateActionClient() / CreateActionServer() factory methods
- AllocateServiceRequest() internal helper for thread-safe srv_id allocation
- QueueRawMessage() for sending data frames without publisher registration
- TryRouteToActionServer() for routing incoming goals to action servers

**SysCommand additions:**
- 6 new constants: __action_client, __action_send_goal, __action_get_result, __action_cancel_goal, __action_server, __action_publish_feedback
- 3 new param structs

**Protocol details:**
- Action client sends __action_send_goal{srv_id} + CDR Goal body, receives UUID-prepended SendGoal_Response
- GetResult response: skips int8 status + 3-byte padding before deserializing Result
- Action server receives goals via existing __request/__response pair (16-byte UUID + CDR Goal), sends feedback via __action_publish_feedback, result via __response
- Feedback routing: SubscribeByMessageName to handle type name inconsistency between __subscribe and __topic_list

### Useful links

- Companion endpoint PR: https://github.com/Unity-Technologies/ROS-TCP-Endpoint/pull/178

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other

## Testing and Verification

Tested end-to-end with action_tutorials_interfaces/Fibonacci action:

1. **Action client** (Unity -> ROS2 fibonacci_action_server): send_goal accepted, 9 feedback messages received with partial_sequence growing correctly, final result [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]

2. **Action server** (ros2 action send_goal -> Unity): goal received, 4 feedback messages published at 1-second intervals, result [0, 1, 1, 2, 3, 5] returned with status SUCCEEDED

3. **Reconnect**: after endpoint restart, feedback subscription re-registers correctly

### Test Configuration:
- Unity Version: Unity 6000.0
- Unity machine OS: Windows 11
- ROS machine OS + version: Ubuntu 22.04, ROS2 Humble
- ROS-Unity communication: TCP (WSL2)
- Endpoint: comoc/ROS-TCP-Endpoint main-ros2 branch

## Checklist
- [x] Ensured this PR is up-to-date with the main branch
- [ ] Created this PR to target the dev branch (Note: dev branch has not been updated since 2022)
- [x] Followed the style guidelines as described in the Contribution Guidelines
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the Changelog
- [ ] Updated the documentation as appropriate

## Notes

This PR requires the companion endpoint changes in [PR #178](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/pull/178). The implementation is backwards-compatible — existing topic/service functionality is completely unaffected. The new Action classes are opt-in; projects that don't use Actions will see no changes in behavior.

The Fibonacci message classes included are hand-written for testing. A future enhancement would add .action file support to the MessageGeneration tool.